### PR TITLE
Don't externalize setTempRet0

### DIFF
--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use clap::{App, Arg};
 use parity_wasm::elements;
 
-use wasm_utils::{CREATE_SYMBOL, CALL_SYMBOL, SET_TEMP_RET_SYMBOL};
+use wasm_utils::{CREATE_SYMBOL, CALL_SYMBOL};
 
 #[derive(Debug)]
 pub enum Error {
@@ -113,7 +113,7 @@ fn main() {
 	let mut ctor_module = module.clone();
 
 	if !matches.is_present("skip_optimization") {
-		wasm_utils::optimize(&mut module, vec![CALL_SYMBOL, SET_TEMP_RET_SYMBOL]).expect("Optimizer to finish without errors");
+		wasm_utils::optimize(&mut module, vec![CALL_SYMBOL]).expect("Optimizer to finish without errors");
 	}
 
 	let raw_module = parity_wasm::serialize(module).expect("Failed to serialize module");
@@ -123,7 +123,7 @@ fn main() {
 	// Otherwise it will just save an optimised raw_module
 	if has_ctor(&ctor_module) {
 		if !matches.is_present("skip_optimization") {
-			wasm_utils::optimize(&mut ctor_module, vec![CREATE_SYMBOL, SET_TEMP_RET_SYMBOL]).expect("Optimizer to finish without errors");
+			wasm_utils::optimize(&mut ctor_module, vec![CREATE_SYMBOL]).expect("Optimizer to finish without errors");
 		}
 		wasm_utils::pack_instance(raw_module, &mut ctor_module);
 		parity_wasm::serialize_to_file(&path, ctor_module).expect("Failed to serialize to file");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ extern crate byteorder;
 
 pub static CREATE_SYMBOL: &'static str = "_create";
 pub static CALL_SYMBOL: &'static str = "_call";
-pub static SET_TEMP_RET_SYMBOL: &'static str = "setTempRet0";
 
 pub mod rules;
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -103,7 +103,6 @@ mod test {
     use parity_wasm::ModuleInstanceInterface;
     use super::*;
     use super::super::optimize;
-    use super::super::SET_TEMP_RET_SYMBOL;
     use byteorder::{ByteOrder, LittleEndian};
 
     #[test]
@@ -150,8 +149,8 @@ mod test {
         .build();
 
         let mut ctor_module = module.clone();
-        optimize(&mut module, vec![CALL_SYMBOL, SET_TEMP_RET_SYMBOL]).expect("Optimizer to finish without errors");
-        optimize(&mut ctor_module, vec![CREATE_SYMBOL, SET_TEMP_RET_SYMBOL]).expect("Optimizer to finish without errors");
+        optimize(&mut module, vec![CALL_SYMBOL]).expect("Optimizer to finish without errors");
+        optimize(&mut ctor_module, vec![CREATE_SYMBOL]).expect("Optimizer to finish without errors");
 
         let raw_module = parity_wasm::serialize(module).unwrap();
         pack_instance(raw_module.clone(), &mut ctor_module);


### PR DESCRIPTION
It is not longer needed, as we stopped to do legalization for JS FFI.

See also:

- https://github.com/paritytech/wasm-tests/pull/26
- https://github.com/paritytech/pwasm-token-example/pull/6