### PR TITLE
Allow wasm-build to handle wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "1"
 
 [dev-dependencies]
 tempdir = "0.3"
+pwasm-emscripten = { git = "https://github.com/paritytech/parity-wasm", path = "pwasm-emscripten" }
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-parity-wasm = "0.15"
+parity-wasm = "0.18"
 log = "0.3"
 env_logger = "0.4"
 lazy_static = "0.2"

--- a/build/Cargo.lock
+++ b/build/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.15.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,7 +275,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-utils 0.1.0",
 ]
@@ -290,7 +290,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -321,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parity-wasm 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "235801e9531998c4bb307f4ea6833c9f40a4cf132895219ac8c2cd25a9b310f7"
+"checksum parity-wasm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f02e35fda913b8873799b817dcab145d1f935a900722ab7274027949d9947a56"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"

--- a/build/Cargo.toml
+++ b/build/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["NikVolf <nikvolf@gmail.com>"]
 glob = "0.2"
 wasm-utils = { path = "../" }
 clap = "2.24"
-parity-wasm = "0.15"
+parity-wasm = "0.18"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -41,8 +41,8 @@ pub fn process_output(input: &source::SourceInput) -> Result<(), Error> {
 	let wasm_name = input.bin_name().to_string().replace("-", "_");
 	cargo_path.push(
 		match input.target() {
-			source::SourceTarget::Emscripten => source::EMSCRIPTEN_PATH,
-			source::SourceTarget::Unknown => source::UNKNOWN_PATH,
+			source::SourceTarget::Emscripten => source::EMSCRIPTEN_TRIPLET,
+			source::SourceTarget::Unknown => source::UNKNOWN_TRIPLET,
 		}
 	);
 	cargo_path.push("release");
@@ -104,13 +104,13 @@ fn main() {
     let wasm_binary = matches.value_of("wasm").expect("is required; qed");
 	let mut source_input = source::SourceInput::new(target_dir, wasm_binary);
 
-	let source_target_val = matches.value_of("source_target").unwrap_or_else(|| source::EMSCRIPTEN_PATH);
-	if source_target_val == source::UNKNOWN_PATH {
+	let source_target_val = matches.value_of("source_target").unwrap_or_else(|| source::EMSCRIPTEN_TRIPLET);
+	if source_target_val == source::UNKNOWN_TRIPLET {
 		source_input = source_input.unknown()
-	} else if source_target_val == source::EMSCRIPTEN_PATH {
+	} else if source_target_val == source::EMSCRIPTEN_TRIPLET {
 		source_input = source_input.emscripten()
 	} else {
-		println!("--target can be: '{}' or '{}'", source::EMSCRIPTEN_PATH, source::UNKNOWN_PATH);
+		println!("--target can be: '{}' or '{}'", source::EMSCRIPTEN_TRIPLET, source::UNKNOWN_TRIPLET);
 		::std::process::exit(1);
 	}
 

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -39,7 +39,7 @@ pub fn wasm_path(input: &source::SourceInput) -> String {
 pub fn process_output(input: &source::SourceInput) -> Result<(), Error> {
 	let mut cargo_path = PathBuf::from(input.target_dir());
 	let wasm_name = input.bin_name().to_string().replace("-", "_");
-	cargo_path.push("wasm32-unknown-emscripten");
+	cargo_path.push(source::EMSCRIPTEN_PATH);
 	cargo_path.push("release");
 	cargo_path.push(format!("{}.wasm", wasm_name));
 
@@ -91,13 +91,13 @@ fn main() {
     let wasm_binary = matches.value_of("wasm").expect("is required; qed");
 	let mut source_input = source::SourceInput::new(target_dir, wasm_binary);
 
-	let source_target_val = matches.value_of("source_target").unwrap_or_else(|| "wasm32-unknown-emscripten");
-	if source_target_val == "wasm32-unknown-unknown" {
+	let source_target_val = matches.value_of("source_target").unwrap_or_else(|| source::EMSCRIPTEN_PATH);
+	if source_target_val == source::UNKNOWN_PATH {
 		source_input = source_input.unknown()
-	} else if source_target_val == "wasm32-unknown-emscripten" {
+	} else if source_target_val == source::EMSCRIPTEN_PATH {
 		source_input = source_input.emscripten()
 	} else {
-		println!("--target can be: 'wasm32-unknown-emscripten' or 'wasm32-unknown-unknown'");
+		println!("--target can be: '{}' or '{}'", source::EMSCRIPTEN_PATH, source::UNKNOWN_PATH);
 		::std::process::exit(1);
 	}
 
@@ -138,7 +138,6 @@ fn main() {
 		let mut file = fs::File::create(&path).expect("Failed to create file");
 		file.write_all(&raw_module).expect("Failed to write module to file");
 	}
-
 }
 
 #[cfg(test)]

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -94,6 +94,10 @@ fn main() {
 			.help("Final wasm binary name")
 			.takes_value(true)
 			.long("final"))
+		.arg(Arg::with_name("save_raw")
+			.help("Save intermediate raw bytecode to path")
+			.takes_value(true)
+			.long("save-raw"))
 		.get_matches();
 
     let target_dir = matches.value_of("target").expect("is required; qed");
@@ -138,6 +142,11 @@ fn main() {
 
 	if !matches.is_present("skip_optimization") {
 		wasm_utils::optimize(&mut module, vec![CALL_SYMBOL]).expect("Optimizer to finish without errors");
+	}
+
+	if let Some(save_raw_path) = matches.value_of("save_raw") {
+		parity_wasm::serialize_to_file(save_raw_path, module.clone())
+			.expect("Failed to write intermediate module");
 	}
 
 	let raw_module = parity_wasm::serialize(module).expect("Failed to serialize module");

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
 			.takes_value(true)
 			.long("runtime-version"))
 		.arg(Arg::with_name("source_target")
-			.help("Cargo target type kind (wasm32-unknown-unknown/emscripten)")
+			.help("Cargo target type kind ('wasm32-unknown-unknown' or 'wasm32-unknown-emscripten'")
 			.takes_value(true)
 			.long("target"))
 		.arg(Arg::with_name("final_name")

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
 			.takes_value(true)
 			.long("runtime-version"))
 		.arg(Arg::with_name("source_target")
-			.help("Skip symbol optimization step producing final wasm")
+			.help("Cargo target type kind (wasm32-unknown-unknown/emscripten)")
 			.takes_value(true)
 			.long("target"))
 		.arg(Arg::with_name("final_name")

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -161,5 +161,4 @@ mod tests {
 			fs::metadata(tmp_dir.path().join("example-wasm.wasm")).expect("metadata failed").is_file()
 		)
 	}
-
 }

--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -81,11 +81,25 @@ fn main() {
 			.help("Injects RUNTIME_VERSION global export")
 			.takes_value(true)
 			.long("runtime-version"))
+		.arg(Arg::with_name("source_target")
+			.help("Skip symbol optimization step producing final wasm")
+			.takes_value(true)
+			.long("target"))
 		.get_matches();
 
     let target_dir = matches.value_of("target").expect("is required; qed");
     let wasm_binary = matches.value_of("wasm").expect("is required; qed");
-	let source_input = source::SourceInput::new(target_dir, wasm_binary);
+	let mut source_input = source::SourceInput::new(target_dir, wasm_binary);
+
+	let source_target_val = matches.value_of("source_target").unwrap_or_else(|| "wasm32-unknown-emscripten");
+	if source_target_val == "wasm32-unknown-unknown" {
+		source_input = source_input.unknown()
+	} else if source_target_val == "wasm32-unknown-emscripten" {
+		source_input = source_input.emscripten()
+	} else {
+		println!("--target can be: 'wasm32-unknown-emscripten' or 'wasm32-unknown-unknown'");
+		::std::process::exit(1);
+	}
 
 	process_output(&source_input).expect("Failed to process cargo target directory");
 

--- a/build/src/source.rs
+++ b/build/src/source.rs
@@ -1,5 +1,8 @@
 //! Configuration of source binaries
 
+pub const UNKNOWN_PATH: &str = "wasm32-unknown-unknown";
+pub const EMSCRIPTEN_PATH: &str = "wasm32-unknown-emscripten";
+
 /// Target configiration of previous build step
 #[derive(Debug)]
 pub enum SourceTarget {

--- a/build/src/source.rs
+++ b/build/src/source.rs
@@ -1,0 +1,44 @@
+//! Configuration of source binaries
+
+/// Target configiration of previous build step
+#[derive(Debug)]
+pub enum SourceTarget {
+	Emscripten,
+	Unknown,
+}
+
+/// Configuration of previous build step (cargo compilation)
+#[derive(Debug)]
+pub struct SourceInput<'a> {
+	target_dir: &'a str,
+	bin_name: &'a str,
+	target: SourceTarget,
+}
+
+impl<'a> SourceInput<'a> {
+	pub fn new<'b>(target_dir: &'b str, bin_name: &'b str) -> SourceInput<'b> {
+		SourceInput {
+			target_dir: target_dir,
+			bin_name: bin_name,
+			target: SourceTarget::Emscripten,
+		}
+	}
+
+	pub fn unknown(mut self) -> Self {
+		self.target = SourceTarget::Unknown;
+		self
+	}
+
+	pub fn emscripten(mut self) -> Self {
+		self.target = SourceTarget::Emscripten;
+		self
+	}
+
+	pub fn target_dir(&self) -> &str {
+		&self.target_dir
+	}
+
+	pub fn bin_name(&self) -> &str {
+		&self.bin_name
+	}
+}

--- a/build/src/source.rs
+++ b/build/src/source.rs
@@ -4,7 +4,7 @@ pub const UNKNOWN_PATH: &str = "wasm32-unknown-unknown";
 pub const EMSCRIPTEN_PATH: &str = "wasm32-unknown-emscripten";
 
 /// Target configiration of previous build step
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum SourceTarget {
 	Emscripten,
 	Unknown,
@@ -15,6 +15,7 @@ pub enum SourceTarget {
 pub struct SourceInput<'a> {
 	target_dir: &'a str,
 	bin_name: &'a str,
+	final_name: &'a str,
 	target: SourceTarget,
 }
 
@@ -23,6 +24,7 @@ impl<'a> SourceInput<'a> {
 		SourceInput {
 			target_dir: target_dir,
 			bin_name: bin_name,
+			final_name: bin_name,
 			target: SourceTarget::Emscripten,
 		}
 	}
@@ -37,11 +39,24 @@ impl<'a> SourceInput<'a> {
 		self
 	}
 
+	pub fn with_final(mut self, final_name: &'a str) -> Self {
+		self.final_name = final_name;
+		self
+	}
+
 	pub fn target_dir(&self) -> &str {
-		&self.target_dir
+		self.target_dir
 	}
 
 	pub fn bin_name(&self) -> &str {
-		&self.bin_name
+		self.bin_name
+	}
+
+	pub fn final_name(&self) -> &str {
+		self.final_name
+	}
+
+	pub fn target(&self) -> SourceTarget {
+		self.target
 	}
 }

--- a/build/src/source.rs
+++ b/build/src/source.rs
@@ -1,7 +1,7 @@
 //! Configuration of source binaries
 
-pub const UNKNOWN_PATH: &str = "wasm32-unknown-unknown";
-pub const EMSCRIPTEN_PATH: &str = "wasm32-unknown-emscripten";
+pub const UNKNOWN_TRIPLET: &str = "wasm32-unknown-unknown";
+pub const EMSCRIPTEN_TRIPLET: &str = "wasm32-unknown-emscripten";
 
 /// Target configiration of previous build step
 #[derive(Debug, Clone, Copy)]

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-parity-wasm = "0.15"
+parity-wasm = "0.18"
 wasm-utils = { path = "../" }

--- a/gas/Cargo.toml
+++ b/gas/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-parity-wasm = "0.15"
+parity-wasm = "0.18"
 wasm-utils = { path = "../" }

--- a/prune/Cargo.toml
+++ b/prune/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-parity-wasm = "0.15"
+parity-wasm = "0.18"
 wasm-utils = { path = "../" }
 clap = "2.24"

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -18,6 +18,28 @@ pub fn update_call_index(opcodes: &mut elements::Opcodes, original_imports: usiz
 	}
 }
 
+pub fn memory_section<'a>(module: &'a mut elements::Module) -> Option<&'a mut elements::MemorySection> {
+   for section in module.sections_mut() {
+		match section {
+			&mut elements::Section::Memory(ref mut sect) => {
+				return Some(sect);
+			},
+			_ => { }
+		}
+	}
+	None
+}
+
+pub fn externalize_mem(mut module: elements::Module) -> elements::Module {
+	let entry = memory_section(&mut module)
+		.expect("Memory section to exist")
+		.entries_mut()
+		.pop()
+		.expect("Own memory entry to exist in memory section");
+
+	module
+}
+
 pub fn externalize(
 	module: elements::Module,
 	replaced_funcs: Vec<&str>,

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,4 +1,5 @@
 use parity_wasm::{elements, builder};
+use optimizer::import_section;
 
 type Insertion = (usize, u32, u32, String);
 
@@ -36,6 +37,14 @@ pub fn externalize_mem(mut module: elements::Module) -> elements::Module {
 		.entries_mut()
 		.pop()
 		.expect("Own memory entry to exist in memory section");
+
+	import_section(&mut module).expect("Import section to exist").entries_mut().push(
+		elements::ImportEntry::new(
+			"env".to_owned(),
+			"memory".to_owned(),
+			elements::External::Memory(entry),
+		)
+	);
 
 	module
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,5 +1,5 @@
 use parity_wasm::{elements, builder};
-use optimizer::import_section;
+use optimizer::{import_section, export_section};
 
 type Insertion = (usize, u32, u32, String);
 
@@ -46,6 +46,20 @@ pub fn externalize_mem(mut module: elements::Module) -> elements::Module {
 		)
 	);
 
+	module
+}
+
+pub fn underscore_funcs(mut module: elements::Module) -> elements::Module {
+	for entry in import_section(&mut module).expect("Import section to exist").entries_mut() {
+		if let elements::External::Function(_) = *entry.external() {
+			entry.field_mut().insert(0, '_');
+		}
+	}
+	for entry in export_section(&mut module).expect("Import section to exist").entries_mut() {
+		if let elements::Internal::Function(_) = *entry.internal() {
+			entry.field_mut().insert(0, '_');
+		}
+	}
 	module
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod runtime_type;
 pub use optimizer::{optimize, Error as OptimizerError};
 pub use gas::inject_gas_counter;
 pub use logger::init_log;
-pub use ext::{externalize, externalize_mem};
+pub use ext::{externalize, externalize_mem, underscore_funcs};
 pub use pack::pack_instance;
 pub use nondeterminism_check::is_deterministic;
 pub use runtime_type::inject_runtime_type;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod runtime_type;
 pub use optimizer::{optimize, Error as OptimizerError};
 pub use gas::inject_gas_counter;
 pub use logger::init_log;
-pub use ext::externalize;
+pub use ext::{externalize, externalize_mem};
 pub use pack::pack_instance;
 pub use nondeterminism_check::is_deterministic;
 pub use runtime_type::inject_runtime_type;


### PR DESCRIPTION
- underscores imports/exports
- externalizes memory

added few options:

```
OPTIONS:
        --final <final_name>                   Final wasm binary name
        --save-raw <save_raw>                  Save intermediate raw bytecode to path
        --target <source_target>               Cargo target type kind (wasm32-unknown-unknown/emscripten)
```
