### PR TITLE
wasm-unknown-unknown: remove start section from a module

### DIFF
--- a/build/src/main.rs
+++ b/build/src/main.rs
@@ -125,7 +125,15 @@ fn main() {
 	let mut module = parity_wasm::deserialize_file(&path).unwrap();
 
 	if let source::SourceTarget::Unknown = source_input.target() {
-		module = underscore_funcs(module)
+		module = underscore_funcs(module);
+		// Removes the start section for 'wasm32-unknown-unknown' target if exists
+		module.sections_mut().retain(|section| {
+			if let &elements::Section::Start(ref _a) = section {
+				false
+			} else {
+				true
+			}
+		});
 	}
 
 	if let Some(runtime_type) = matches.value_of("runtime_type") {


### PR DESCRIPTION
wasm-unknown-unknown couldn't be linked as a binary w/o main