### PR TITLE
Fixed typo

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -62,7 +62,7 @@ impl ::std::str::FromStr for InstructionType {
             "reinterpret" => Ok(InstructionType::Reinterpretation),
             "unreachable" => Ok(InstructionType::Unreachable),
             "nop" => Ok(InstructionType::Nop),
-            "currrent_mem" => Ok(InstructionType::CurrentMemory),
+            "current_mem" => Ok(InstructionType::CurrentMemory),
             "grow_mem" => Ok(InstructionType::GrowMemory),
             _ => Err(UnknownInstruction),
         }


### PR DESCRIPTION
I think the current spec says something even different than what I corrected:
`memory.size`
and
`memory.grow`