### PR TITLE
Introduce substrate contracts support.

### DIFF
--- a/cli/pack/main.rs
+++ b/cli/pack/main.rs
@@ -8,6 +8,8 @@ use clap::{App, Arg};
 fn main() {
     logger::init_log();
 
+	let target_runtime = utils::TargetRuntime::pwasm();
+
     let matches = App::new("wasm-pack")
                         .arg(Arg::with_name("input")
                             .index(1)
@@ -27,9 +29,9 @@ fn main() {
 	let raw_module = parity_wasm::serialize(module).expect("Serialization failed");
 
     // Invoke packer
-    let mut result_module = utils::pack_instance(raw_module, ctor_module).expect("Packing failed");
+    let mut result_module = utils::pack_instance(raw_module, ctor_module, &utils::TargetRuntime::pwasm()).expect("Packing failed");
     // Optimize constructor, since it does not need everything
-    utils::optimize(&mut result_module, vec![utils::CALL_SYMBOL]).expect("Optimization failed");
+    utils::optimize(&mut result_module, vec![target_runtime.call_symbol]).expect("Optimization failed");
 
     parity_wasm::serialize_to_file(&output, result_module).expect("Serialization failed");
 }

--- a/cli/prune/main.rs
+++ b/cli/prune/main.rs
@@ -8,6 +8,8 @@ use clap::{App, Arg};
 fn main() {
     logger::init_log();
 
+	let target_runtime = utils::TargetRuntime::pwasm();
+
     let matches = App::new("wasm-prune")
                         .arg(Arg::with_name("input")
                             .index(1)
@@ -22,12 +24,12 @@ fn main() {
                             .short("e")
                             .takes_value(true)
                             .value_name("functions")
-                            .help(&format!("Comma-separated list of exported functions to keep. Default: '{}'", utils::CALL_SYMBOL)))
+                            .help(&format!("Comma-separated list of exported functions to keep. Default: '{}'", target_runtime.call_symbol)))
                         .get_matches();
 
     let exports = matches
                     .value_of("exports")
-                    .unwrap_or(utils::CALL_SYMBOL)
+                    .unwrap_or(target_runtime.call_symbol)
                     .split(',')
                     .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,6 @@ extern crate parity_wasm;
 extern crate byteorder;
 #[macro_use] extern crate log;
 
-pub static CREATE_SYMBOL: &'static str = "deploy";
-pub static CALL_SYMBOL: &'static str = "call";
-pub static RET_SYMBOL: &'static str = "ret";
-
 pub mod rules;
 
 mod build;
@@ -31,6 +27,30 @@ pub use gas::inject_gas_counter;
 pub use ext::{externalize, externalize_mem, underscore_funcs, ununderscore_funcs, shrink_unknown_stack};
 pub use pack::{pack_instance, Error as PackingError};
 pub use runtime_type::inject_runtime_type;
+
+pub struct TargetRuntime {
+	pub create_symbol: &'static str,
+	pub call_symbol: &'static str,
+	pub return_symbol: &'static str,
+}
+
+impl TargetRuntime {
+	pub fn substrate() -> TargetRuntime {
+		TargetRuntime {
+			create_symbol: "deploy",
+			call_symbol: "call",
+			return_symbol: "ext_return",
+		}
+	}
+
+	pub fn pwasm() -> TargetRuntime {
+		TargetRuntime {
+			create_symbol: "deploy",
+			call_symbol: "call",
+			return_symbol: "ret",
+		}
+	}
+}
 
 #[cfg(not(feature = "std"))]
 mod std {


### PR DESCRIPTION
For now, the only difference in the RET_SYMBOL, but I'm expecting the runtimes and their runtimes will diverge with time. 

For now, only wasm-build is updated, to let us start experimenting with new contract runtime. 