### PR TITLE
Higher level wasm representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = { version = "1", default-features = false }
 tempdir = "0.3"
 wabt = "0.2"
 diff = "0.1.11"
+indoc = "0.3"
 
 [features]
 default = ["std"]

--- a/examples/opt_imports.rs
+++ b/examples/opt_imports.rs
@@ -1,0 +1,28 @@
+extern crate pwasm_utils as utils;
+
+use std::env;
+
+fn main() {
+	let args = env::args().collect::<Vec<_>>();
+	if args.len() != 3 {
+		println!("Usage: {} input_file.wasm output_file.wasm", args[0]);
+		return;
+	}
+
+	// Loading module
+	let mut module = utils::Module::from_elements(
+		&parity_wasm::deserialize_file(&args[1]).expect("Module deserialization to succeed")
+	).expect("Failed to parse parity-wasm format");
+
+	let mut delete_types = Vec::new();
+	for type_ in module.types.iter() {
+		if type_.link_count() == 0 {
+			delete_types.push(type_.order().expect("type in list should have index"));
+		}
+	}
+	module.types.delete(&delete_types[..]);
+
+	parity_wasm::serialize_to_file(&args[2],
+		module.generate().expect("Failed to generate valid format")
+	).expect("Module serialization to succeed")
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -9,6 +9,18 @@ enum ImportedOrDeclared<T=()> {
 	Declared(T),
 }
 
+impl<T> ImportedOrDeclared<T> {
+	fn imported(module: String, name: String) -> Self {
+		ImportedOrDeclared::Imported(module, name)
+	}
+}
+
+impl<T> From<&elements::ImportEntry> for ImportedOrDeclared<T> {
+	fn from(v: &elements::ImportEntry) -> Self {
+		ImportedOrDeclared::Imported(v.module().to_owned(), v.field().to_owned())
+	}
+}
+
 type FuncOrigin = ImportedOrDeclared<Vec<Instruction>>;
 type GlobalOrigin = ImportedOrDeclared<Vec<Instruction>>;
 type MemoryOrigin = ImportedOrDeclared;
@@ -17,16 +29,30 @@ type TableOrigin = ImportedOrDeclared;
 type TypeRef = Rc<RefCell<elements::Type>>;
 type FuncRef = Rc<RefCell<Func>>;
 type GlobalRef = Rc<RefCell<Global>>;
+type MemoryRef = Rc<RefCell<Memory>>;
+type TableRef = Rc<RefCell<Table>>;
 
 struct Func {
 	type_ref: TypeRef,
 	origin: FuncOrigin,
 }
 
+impl Func {
+	fn into_ref(self) -> Rc<RefCell<Self>> {
+		Rc::from(RefCell::from(self))
+	}
+}
+
 struct Global {
 	content: elements::ValueType,
 	is_mut: bool,
 	origin: GlobalOrigin,
+}
+
+impl Global {
+	fn into_ref(self) -> Rc<RefCell<Self>> {
+		Rc::from(RefCell::from(self))
+	}
 }
 
 enum Instruction {
@@ -39,8 +65,21 @@ struct Memory {
 	origin: MemoryOrigin,
 }
 
+impl Memory {
+	fn into_ref(self) -> Rc<RefCell<Self>> {
+		Rc::from(RefCell::from(self))
+	}
+}
+
 struct Table {
 	origin: TableOrigin,
+	limits: elements::ResizableLimits,
+}
+
+impl Table {
+	fn into_ref(self) -> Rc<RefCell<Self>> {
+		Rc::from(RefCell::from(self))
+	}
 }
 
 struct DataSegment {
@@ -56,14 +95,16 @@ struct ElementSegment {
 enum Export {
 	Func(FuncRef),
 	Global(GlobalRef),
+	Table(TableRef),
+	Memory(MemoryRef),
 }
 
 #[derive(Default)]
 struct Module {
 	types: Vec<TypeRef>,
 	funcs: Vec<FuncRef>,
-	tables: Vec<Table>,
-	memories: Vec<Memory>,
+	tables: Vec<TableRef>,
+	memory: Vec<MemoryRef>,
 	globals: Vec<GlobalRef>,
 	elements: Vec<ElementSegment>,
 	data: Vec<DataSegment>,
@@ -72,7 +113,6 @@ struct Module {
 
 impl Module {
 
-
 	fn from_elements(module: &elements::Module) -> Self {
 
 		let mut res = Module::default();
@@ -80,7 +120,44 @@ impl Module {
 		for section in module.sections() {
 			match section {
 				elements::Section::Type(type_section) => {
-					res.types = type_section.types().iter().cloned().map(|t| Rc::new(RefCell::new(t))).collect();
+					res.types = type_section
+						.types()
+						.iter()
+						.cloned()
+						.map(RefCell::<_>::from)
+						.map(Rc::<_>::from)
+						.collect();
+				},
+				elements::Section::Import(import_section) => {
+					for entry in import_section.entries() {
+						match *entry.external() {
+							elements::External::Function(f) => {
+								res.funcs.push(Func {
+									type_ref: res.types[f as usize].clone(),
+									origin: entry.into(),
+								}.into_ref())
+							},
+							elements::External::Memory(m) => {
+								res.memory.push(Memory {
+									limits: m.limits().clone(),
+									origin: entry.into(),
+								}.into_ref())
+							},
+							elements::External::Global(g) => {
+								res.globals.push(Global {
+									content: g.content_type(),
+									is_mut: g.is_mutable(),
+									origin: entry.into(),
+								}.into_ref())
+							},
+							elements::External::Table(t) => {
+								res.tables.push(Table {
+									limits: t.limits().clone(),
+									origin: entry.into(),
+								}.into_ref())
+							},
+						}
+					}
 				},
 				_ => continue,
 			}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,7 +7,7 @@ use std::borrow::ToOwned;
 use std::string::String;
 use std::collections::BTreeMap;
 
-enum ImportedOrDeclared<T=()> {
+pub enum ImportedOrDeclared<T=()> {
 	Imported(String, String),
 	Declared(T),
 }
@@ -18,82 +18,82 @@ impl<T> From<&elements::ImportEntry> for ImportedOrDeclared<T> {
 	}
 }
 
-type FuncOrigin = ImportedOrDeclared<Vec<Instruction>>;
-type GlobalOrigin = ImportedOrDeclared<Vec<Instruction>>;
-type MemoryOrigin = ImportedOrDeclared;
-type TableOrigin = ImportedOrDeclared;
+pub type FuncOrigin = ImportedOrDeclared<Vec<Instruction>>;
+pub type GlobalOrigin = ImportedOrDeclared<Vec<Instruction>>;
+pub type MemoryOrigin = ImportedOrDeclared;
+pub type TableOrigin = ImportedOrDeclared;
 
-struct Func {
-	type_ref: EntryRef<elements::Type>,
-	origin: FuncOrigin,
+pub struct Func {
+	pub type_ref: EntryRef<elements::Type>,
+	pub origin: FuncOrigin,
 }
 
-struct Global {
-	content: elements::ValueType,
-	is_mut: bool,
-	origin: GlobalOrigin,
+pub struct Global {
+	pub content: elements::ValueType,
+	pub is_mut: bool,
+	pub origin: GlobalOrigin,
 }
 
-enum Instruction {
+pub enum Instruction {
 	Plain(elements::Instruction),
 	Call(EntryRef<Func>),
 }
 
-struct Memory {
-	limits: elements::ResizableLimits,
-	origin: MemoryOrigin,
+pub struct Memory {
+	pub limits: elements::ResizableLimits,
+	pub origin: MemoryOrigin,
 }
 
-struct Table {
-	origin: TableOrigin,
-	limits: elements::ResizableLimits,
+pub struct Table {
+	pub origin: TableOrigin,
+	pub limits: elements::ResizableLimits,
 }
 
-enum SegmentLocation {
+pub enum SegmentLocation {
 	Passive,
 	Default(Vec<Instruction>),
 	WithIndex(u32, Vec<Instruction>),
 }
 
-struct DataSegment {
-	location: SegmentLocation,
-	value: Vec<u8>,
+pub struct DataSegment {
+	pub location: SegmentLocation,
+	pub value: Vec<u8>,
 }
 
-struct ElementSegment {
-	location: SegmentLocation,
-	value: Vec<u32>,
+pub struct ElementSegment {
+	pub location: SegmentLocation,
+	pub value: Vec<u32>,
 }
 
-enum ExportLocal {
+pub enum ExportLocal {
 	Func(EntryRef<Func>),
 	Global(EntryRef<Global>),
 	Table(EntryRef<Table>),
 	Memory(EntryRef<Memory>),
 }
 
-struct Export {
-	name: String,
-	local: ExportLocal,
+pub struct Export {
+	pub name: String,
+	pub local: ExportLocal,
 }
 
 #[derive(Default)]
-struct Module {
-	types: RefList<elements::Type>,
-	funcs: RefList<Func>,
-	memory: RefList<Memory>,
-	tables: RefList<Table>,
-	globals: RefList<Global>,
-	start: Option<EntryRef<Func>>,
-	exports: Vec<Export>,
-	elements: Vec<ElementSegment>,
-	data: Vec<DataSegment>,
-	other: BTreeMap<usize, elements::Section>,
+pub struct Module {
+	pub types: RefList<elements::Type>,
+	pub funcs: RefList<Func>,
+	pub memory: RefList<Memory>,
+	pub tables: RefList<Table>,
+	pub globals: RefList<Global>,
+	pub start: Option<EntryRef<Func>>,
+	pub exports: Vec<Export>,
+	pub elements: Vec<ElementSegment>,
+	pub data: Vec<DataSegment>,
+	pub other: BTreeMap<usize, elements::Section>,
 }
 
 impl Module {
 
-	fn from_elements(module: &elements::Module) -> Self {
+	pub fn from_elements(module: &elements::Module) -> Self {
 
 		let mut idx = 0;
 		let mut res = Module::default();
@@ -469,7 +469,6 @@ impl Module {
 						ExportLocal::Memory(ref memory_ref) => {
 							elements::Internal::Memory(memory_ref.order().expect("detached memory ref") as u32)
 						},
-						_ => continue,
 					};
 
 					exports.push(elements::ExportEntry::new(export.name.to_owned(), internal));
@@ -521,7 +520,7 @@ impl Module {
 			// CODE SECTION (10)
 			let mut code_section = elements::CodeSection::default();
 			{
-				let mut funcs = code_section.bodies_mut();
+				let funcs = code_section.bodies_mut();
 
 				for func in self.funcs.iter() {
 					match func.read().origin {
@@ -587,11 +586,11 @@ fn custom_round(
 	}
 }
 
-fn parse(wasm: &[u8]) -> Module {
+pub fn parse(wasm: &[u8]) -> Module {
 	Module::from_elements(&::parity_wasm::deserialize_buffer(wasm).expect("failed to parse wasm"))
 }
 
-fn generate(f: &Module) -> Vec<u8> {
+pub fn generate(f: &Module) -> Vec<u8> {
 	let pm = f.generate();
 	::parity_wasm::serialize(pm).expect("failed to generate wasm")
 }
@@ -600,7 +599,6 @@ fn generate(f: &Module) -> Vec<u8> {
 mod tests {
 
 	extern crate wabt;
-	use parity_wasm;
 
 	#[test]
 	fn smoky() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -835,8 +835,5 @@ mod tests {
 			/// type should be the same, #1
 			assert_eq!(ftype.params().len(), 1);
 		}
-
 	}
-
-
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -869,6 +869,7 @@ mod tests {
 
 		{
 			let type_ref_0 = sample.types.clone_ref(0);
+			let declared_func_2 = sample.funcs.clone_ref(2);
 
 			let mut tx = sample.funcs.begin_insert_not_until(
 				|f| match f.origin {
@@ -885,6 +886,20 @@ mod tests {
 			tx.done();
 
 			assert_eq!(new_import_func.order(), Some(1));
+			assert_eq!(declared_func_2.order(), Some(3));
+			assert_eq!(
+				match &declared_func_2.read().origin {
+					super::ImportedOrDeclared::Declared(ref body) => {
+						match body.code[1] {
+							super::Instruction::Call(ref called_func) => called_func.order(),
+							_ => panic!("instruction #2 should be a call!"),
+						}
+					},
+					_ => panic!("func #4 should be declared!"),
+				},
+				Some(2),
+				"Call should be recalculated to 2"
+			);
 		}
 
 		validate_sample(&sample);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,97 @@
+//! Wasm binary graph format
+
+use parity_wasm::elements;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+enum ImportedOrDeclared<T=()> {
+	Imported(String, String),
+	Declared(T),
+}
+
+type FuncOrigin = ImportedOrDeclared<Vec<Instruction>>;
+type GlobalOrigin = ImportedOrDeclared<Vec<Instruction>>;
+type MemoryOrigin = ImportedOrDeclared;
+type TableOrigin = ImportedOrDeclared;
+
+type TypeRef = Rc<RefCell<elements::Type>>;
+type FuncRef = Rc<RefCell<Func>>;
+type GlobalRef = Rc<RefCell<Global>>;
+
+struct Func {
+	type_ref: TypeRef,
+	origin: FuncOrigin,
+}
+
+struct Global {
+	content: elements::ValueType,
+	is_mut: bool,
+	origin: GlobalOrigin,
+}
+
+enum Instruction {
+	Plain(elements::Instruction),
+	Call(FuncRef),
+}
+
+struct Memory {
+	limits: elements::ResizableLimits,
+	origin: MemoryOrigin,
+}
+
+struct Table {
+	origin: TableOrigin,
+}
+
+struct DataSegment {
+	offset_expr: Vec<Instruction>,
+	data: Vec<u8>,
+}
+
+struct ElementSegment {
+	offset_expr: Vec<Instruction>,
+	data: Vec<u32>,
+}
+
+enum Export {
+	Func(FuncRef),
+	Global(GlobalRef),
+}
+
+#[derive(Default)]
+struct Module {
+	types: Vec<TypeRef>,
+	funcs: Vec<FuncRef>,
+	tables: Vec<Table>,
+	memories: Vec<Memory>,
+	globals: Vec<GlobalRef>,
+	elements: Vec<ElementSegment>,
+	data: Vec<DataSegment>,
+	exports: Vec<Export>,
+}
+
+impl Module {
+
+
+	fn from_elements(module: &elements::Module) -> Self {
+
+		let mut res = Module::default();
+
+		for section in module.sections() {
+			match section {
+				elements::Section::Type(type_section) => {
+					res.types = type_section.types().iter().cloned().map(|t| Rc::new(RefCell::new(t))).collect();
+				},
+				_ => continue,
+			}
+		}
+
+		res
+	}
+
+}
+
+#[cfg(test)]
+mod tests {
+
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,7 @@
 //! Wasm binary graph format
 
+#![warn(missing_docs)]
+
 use parity_wasm::elements;
 use super::ref_list::{RefList, EntryRef};
 use std::vec::Vec;
@@ -168,15 +170,25 @@ pub struct Export {
 /// Module
 #[derive(Debug, Default)]
 pub struct Module {
+	/// Refence-tracking list of types.
 	pub types: RefList<elements::Type>,
+	/// Refence-tracking list of funcs.
 	pub funcs: RefList<Func>,
+	/// Refence-tracking list of memory instances.
 	pub memory: RefList<Memory>,
+	/// Refence-tracking list of table instances.
 	pub tables: RefList<Table>,
+	/// Refence-tracking list of globals.
 	pub globals: RefList<Global>,
+	/// Reference to start function.
 	pub start: Option<EntryRef<Func>>,
+	/// References to exported objects.
 	pub exports: Vec<Export>,
+	/// List of element segments.
 	pub elements: Vec<ElementSegment>,
+	/// List of data segments.
 	pub data: Vec<DataSegment>,
+	/// Other module functions that are not decoded or processed.
 	pub other: BTreeMap<usize, elements::Section>,
 }
 
@@ -210,6 +222,7 @@ impl Module {
 		}).collect()
 	}
 
+	/// Initialize module from parity-wasm `Module`.
 	pub fn from_elements(module: &elements::Module) -> Self {
 
 		let mut idx = 0;
@@ -721,10 +734,12 @@ fn custom_round(
 	}
 }
 
+/// New module from parity-wasm `Module`
 pub fn parse(wasm: &[u8]) -> Module {
 	Module::from_elements(&::parity_wasm::deserialize_buffer(wasm).expect("failed to parse wasm"))
 }
 
+/// Generate parity-wasm `Module`
 pub fn generate(f: &Module) -> Vec<u8> {
 	let pm = f.generate();
 	::parity_wasm::serialize(pm).expect("failed to generate wasm")

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -792,15 +792,13 @@ mod tests {
 
 	#[test]
 	fn smoky() {
-		let sample = load_sample(r#"
-(module
-	(type (func))
-	(func (type 0))
-	(memory 0 1)
-	(export "simple" (func 0))
-)
-"#
-		);
+		let sample = load_sample(indoc!(r#"
+			(module
+				(type (func))
+				(func (type 0))
+				(memory 0 1)
+				(export "simple" (func 0)))"#
+		));
 
 		assert_eq!(sample.types.len(), 1);
 		assert_eq!(sample.funcs.len(), 1);
@@ -814,26 +812,26 @@ mod tests {
 
 	#[test]
 	fn table() {
-		let mut sample = load_sample(r#"
-(module
-  (import "env" "foo" (func $foo))
-  (func (param i32)
-     get_local 0
-     i32.const 0
-     call $i32.add
-     drop
-  )
-  (func $i32.add (export "i32.add") (param i32 i32) (result i32)
-    get_local 0
-	get_local 1
-	i32.add
-  )
-  (table 10 anyfunc)
+		let mut sample = load_sample(indoc!(r#"
+			(module
+				(import "env" "foo" (func $foo))
+				(func (param i32)
+					get_local 0
+					i32.const 0
+					call $i32.add
+					drop
+				)
+				(func $i32.add (export "i32.add") (param i32 i32) (result i32)
+					get_local 0
+					get_local 1
+					i32.add
+				)
+				(table 10 anyfunc)
 
-  ;; Refer all types of functions: imported, defined not exported and defined exported.
-  (elem (i32.const 0) 0 1 2)
-)"#
-		);
+				;; Refer all types of functions: imported, defined not exported and defined exported.
+				(elem (i32.const 0) 0 1 2)
+			)"#
+		));
 
 		{
 			let element_func = &sample.elements[0].value[1];
@@ -864,23 +862,23 @@ mod tests {
 
 	#[test]
 	fn new_import() {
-		let mut sample = load_sample(r#"
-(module
-  (type (;0;) (func))
-  (type (;1;) (func (param i32 i32) (result i32)))
-  (import "env" "foo" (func (type 1)))
-  (func (param i32)
-     get_local 0
-     i32.const 0
-     call 0
-     drop
-  )
-  (func (type 0)
-	i32.const 0
-	call 1
-  )
-)"#
-		);
+		let mut sample = load_sample(indoc!(r#"
+			(module
+				(type (;0;) (func))
+				(type (;1;) (func (param i32 i32) (result i32)))
+				(import "env" "foo" (func (type 1)))
+				(func (param i32)
+					get_local 0
+					i32.const 0
+					call 0
+					drop
+				)
+				(func (type 0)
+					i32.const 0
+					call 1
+				)
+			)"#
+		));
 
 		{
 			let type_ref_0 = sample.types.clone_ref(0);
@@ -922,39 +920,38 @@ mod tests {
 
 	#[test]
 	fn simple_opt() {
-		let mut sample = load_sample(r#"
-(module
-  (type (;0;) (func))
-  (type (;1;) (func (param i32 i32) (result i32)))
-  (type (;2;) (func (param i32 i32) (result i32)))
-  (type (;3;) (func (param i32 i32) (result i32)))
-  (import "env" "foo" (func (type 1)))
-  (import "env" "foo2" (func (type 2)))
-  (import "env" "foo3" (func (type 3)))
-  (func (type 0)
-     i32.const 1
-     i32.const 1
-     call 0
-     drop
-  )
-  (func (type 0)
-     i32.const 2
-     i32.const 2
-     call 1
-     drop
-  )
-  (func (type 0)
-     i32.const 3
-     i32.const 3
-     call 2
-     drop
-  )
-  (func (type 0)
-	call 3
-  )
-
-)"#
-		);
+		let mut sample = load_sample(indoc!(r#"
+			(module
+				(type (;0;) (func))
+				(type (;1;) (func (param i32 i32) (result i32)))
+				(type (;2;) (func (param i32 i32) (result i32)))
+				(type (;3;) (func (param i32 i32) (result i32)))
+				(import "env" "foo" (func (type 1)))
+				(import "env" "foo2" (func (type 2)))
+				(import "env" "foo3" (func (type 3)))
+				(func (type 0)
+					i32.const 1
+					i32.const 1
+					call 0
+					drop
+				)
+				(func (type 0)
+					i32.const 2
+					i32.const 2
+					call 1
+					drop
+				)
+				(func (type 0)
+					i32.const 3
+					i32.const 3
+					call 2
+					drop
+				)
+				(func (type 0)
+					call 3
+				)
+			)"#
+		));
 
 		validate_sample(&sample);
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -8,12 +8,6 @@ enum ImportedOrDeclared<T=()> {
 	Declared(T),
 }
 
-impl<T> ImportedOrDeclared<T> {
-	fn imported(module: String, name: String) -> Self {
-		ImportedOrDeclared::Imported(module, name)
-	}
-}
-
 impl<T> From<&elements::ImportEntry> for ImportedOrDeclared<T> {
 	fn from(v: &elements::ImportEntry) -> Self {
 		ImportedOrDeclared::Imported(v.module().to_owned(), v.field().to_owned())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -240,10 +240,8 @@ impl Module {
 						// let location = if element_segment.passive() {
 						// 	SegmentLocation::Passive
 						// } else if element_segment.index() == 0 {
-						// 	// TODO: transform instructions
 						// 	SegmentLocation::Default(Vec::new())
 						// } else {
-						// 	// TODO: transform instructions
 						// 	SegmentLocation::WithIndex(element_segment.index(), Vec::new())
 						// };
 
@@ -492,11 +490,10 @@ impl Module {
 
 				for global in self.globals.iter() {
 					match global.read().origin {
-						Declared(_) => {
+						Declared(ref init_code) => {
 							globals.push(elements::GlobalEntry::new(
 								elements::GlobalType::new(global.read().content, global.read().is_mut),
-								// TODO: generate init expr
-								elements::InitExpr::empty(),
+								elements::InitExpr::new(self.generate_instructions(&init_code[..])),
 							));
 						},
 						_ => continue,
@@ -559,8 +556,7 @@ impl Module {
 							element_segments.push(
 								elements::ElementSegment::new(
 									0,
-									// TODO: generate init expr
-									elements::InitExpr::empty(),
+									elements::InitExpr::new(self.generate_instructions(&offset_expr[..])),
 									element.value.clone(),
 								)
 							);
@@ -584,11 +580,10 @@ impl Module {
 
 				for func in self.funcs.iter() {
 					match func.read().origin {
-						Declared(_) => {
-							// TODO: generate body
+						Declared(ref body) => {
 							funcs.push(elements::FuncBody::new(
-								Vec::new(),
-								elements::Instructions::empty(),
+								body.locals.clone(),
+								elements::Instructions::new(self.generate_instructions(&body.code[..])),
 							));
 						},
 						_ => continue,
@@ -614,8 +609,7 @@ impl Module {
 							data_segments.push(
 								elements::DataSegment::new(
 									0,
-									// TODO: generate init expr
-									elements::InitExpr::empty(),
+									elements::InitExpr::new(self.generate_instructions(&offset_expr[..])),
 									data_entry.value.clone(),
 								)
 							);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -4,10 +4,12 @@
 
 use parity_wasm::elements;
 use super::ref_list::{RefList, EntryRef};
-use std::vec::Vec;
-use std::borrow::ToOwned;
-use std::string::String;
-use std::collections::BTreeMap;
+use std::{
+	vec::Vec,
+	borrow::ToOwned,
+	string::String,
+	collections::BTreeMap,
+};
 
 /// Imported or declared variant of the same thing.
 ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -125,6 +125,22 @@ impl Module {
 						});
 					};
 				},
+				elements::Section::Table(table_section) => {
+					for t in table_section.entries() {
+						res.tables.push(Table {
+							limits: t.limits().clone(),
+							origin: ImportedOrDeclared::Declared(()),
+						});
+					}
+				},
+				elements::Section::Memory(table_section) => {
+					for t in table_section.entries() {
+						res.memory.push(Memory {
+							limits: t.limits().clone(),
+							origin: ImportedOrDeclared::Declared(()),
+						});
+					}
+				},
 				_ => continue,
 			}
 		}
@@ -150,6 +166,7 @@ mod tests {
 			(module
 				(type (func))
 				(func (type 0))
+				(memory 0 1)
 			)
 		"#).expect("Failed to read fixture");
 
@@ -157,5 +174,7 @@ mod tests {
 
 		assert_eq!(f.types.len(), 1);
 		assert_eq!(f.funcs.len(), 1);
+		assert_eq!(f.tables.len(), 0);
+		assert_eq!(f.memory.len(), 1);
 	}
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -410,7 +410,8 @@ impl Module {
 		Ok(res)
 	}
 
-	fn generate(&self) -> Result<elements::Module, Error> {
+	/// Generate raw format representation.
+	pub fn generate(&self) -> Result<elements::Module, Error> {
 		use self::ImportedOrDeclared::*;
 
 		let mut idx = 0;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -48,14 +48,20 @@ struct Table {
 	limits: elements::ResizableLimits,
 }
 
+enum SegmentLocation {
+	Passive,
+	Default(Vec<Instruction>),
+	WithIndex(u32, Vec<Instruction>),
+}
+
 struct DataSegment {
-	offset_expr: Vec<Instruction>,
-	data: Vec<u8>,
+	location: SegmentLocation,
+	value: Vec<u8>,
 }
 
 struct ElementSegment {
-	offset_expr: Vec<Instruction>,
-	data: Vec<u32>,
+	location: SegmentLocation,
+	value: Vec<u32>,
 }
 
 enum ExportLocal {
@@ -180,6 +186,44 @@ impl Module {
 						res.exports.push(Export { local: local, name: e.field().to_owned() })
 					}
 				},
+				elements::Section::Start(start_func) => {
+					res.start = Some(res.funcs.clone_ref(*start_func as usize));
+				},
+				elements::Section::Element(element_section) => {
+					for element_segment in element_section.entries() {
+
+						// let location = if element_segment.passive() {
+						// 	SegmentLocation::Passive
+						// } else if element_segment.index() == 0 {
+						// 	// TODO: transform instructions
+						// 	SegmentLocation::Default(Vec::new())
+						// } else {
+						// 	// TODO: transform instructions
+						// 	SegmentLocation::WithIndex(element_segment.index(), Vec::new())
+						// };
+
+						// TODO: transform instructions
+						// TODO: update parity-wasm and uncomment the above
+						let location = SegmentLocation::Default(Vec::new());
+
+						res.elements.push(ElementSegment {
+							value: element_segment.members().to_vec(),
+							location: location,
+						});
+					}
+				},
+				elements::Section::Data(data_section) => {
+					for data_segment in data_section.entries() {
+						// TODO: transform instructions
+						// TODO: update parity-wasm and uncomment the above
+						let location = SegmentLocation::Default(Vec::new());
+
+						res.data.push(DataSegment {
+							value: data_segment.value().to_vec(),
+							location: location,
+						});
+					}
+				}
 				_ => continue,
 			}
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod symbols;
 mod ext;
 mod pack;
 mod runtime_type;
+mod graph;
 
 pub mod stack_height;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use gas::inject_gas_counter;
 pub use optimizer::{optimize, Error as OptimizerError};
 pub use pack::{pack_instance, Error as PackingError};
 pub use runtime_type::inject_runtime_type;
-pub use graph::{Module, parse, generate};
+pub use graph::{Module, parse as graph_parse, generate as graph_generate};
 pub use ref_list::{RefList, Entry, EntryRef, DeleteTransaction};
 
 pub struct TargetSymbols {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,10 @@ mod std {
 	pub use core::*;
 	pub use alloc::{vec, string, boxed, borrow};
 
+	pub mod rc {
+		pub use alloc::rc::Rc;
+	}
+
 	pub mod collections {
 		pub use alloc::collections::{BTreeMap, BTreeSet};
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod ext;
 mod pack;
 mod runtime_type;
 mod graph;
+mod ref_list;
 
 pub mod stack_height;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub use gas::inject_gas_counter;
 pub use ext::{externalize, externalize_mem, underscore_funcs, ununderscore_funcs, shrink_unknown_stack};
 pub use pack::{pack_instance, Error as PackingError};
 pub use runtime_type::inject_runtime_type;
+pub use graph::{Module, parse, generate};
+pub use ref_list::{RefList, Entry, EntryRef, DeleteTransaction};
 
 pub struct TargetRuntime {
 	pub create_symbol: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@ extern crate alloc;
 
 extern crate byteorder;
 extern crate parity_wasm;
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
+#[cfg(test)] #[macro_use] extern crate indoc;
+
 
 pub mod rules;
 

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -335,14 +335,17 @@ mod tests {
 	#[test]
 	fn order() {
 		let mut list = RefList::<u32>::new();
+		let item00 = list.push(0);
 		let item10 = list.push(10);
 		let item20 = list.push(20);
 		let item30 = list.push(30);
 
-		assert_eq!(item10.order(), Some(0));
-		assert_eq!(item20.order(), Some(1));
-		assert_eq!(item30.order(), Some(2));
+		assert_eq!(item00.order(), Some(0));
+		assert_eq!(item10.order(), Some(1));
+		assert_eq!(item20.order(), Some(2));
+		assert_eq!(item30.order(), Some(3));
 
+		assert_eq!(**item00.read(), 0);
 		assert_eq!(**item10.read(), 10);
 		assert_eq!(**item20.read(), 20);
 		assert_eq!(**item30.read(), 30);
@@ -351,14 +354,18 @@ mod tests {
 	#[test]
 	fn delete() {
 		let mut list = RefList::<u32>::new();
+		let item00 = list.push(0);
 		let item10 = list.push(10);
 		let item20 = list.push(20);
 		let item30 = list.push(30);
 
-		list.begin_delete().push(1).done();
+		list.begin_delete().push(2).done();
 
-		assert_eq!(item10.order(), Some(0));
-		assert_eq!(item30.order(), Some(1));
+		assert_eq!(item00.order(), Some(0));
+		assert_eq!(item10.order(), Some(1));
+		assert_eq!(item30.order(), Some(2));
+
+		// but this was detached
 		assert_eq!(item20.order(), None);
 	}
 
@@ -393,20 +400,22 @@ mod tests {
 	#[test]
 	fn insert() {
 		let mut list = RefList::<u32>::new();
+		let item00 = list.push(0);
 		let item10 = list.push(10);
 		let item20 = list.push(20);
 		let item30 = list.push(30);
 
-		let mut insert_tx = list.begin_insert(2);
+		let mut insert_tx = list.begin_insert(3);
 		let item23 = insert_tx.push(23);
 		let item27 = insert_tx.push(27);
 		insert_tx.done();
 
-		assert_eq!(item10.order(), Some(0));
-		assert_eq!(item20.order(), Some(1));
-		assert_eq!(item23.order(), Some(2));
-		assert_eq!(item27.order(), Some(3));
-		assert_eq!(item30.order(), Some(4));
+		assert_eq!(item00.order(), Some(0));
+		assert_eq!(item10.order(), Some(1));
+		assert_eq!(item20.order(), Some(2));
+		assert_eq!(item23.order(), Some(3));
+		assert_eq!(item27.order(), Some(4));
+		assert_eq!(item30.order(), Some(5));
 	}
 
 	#[test]
@@ -436,6 +445,7 @@ mod tests {
 	#[test]
 	fn insert_after() {
 		let mut list = RefList::<u32>::new();
+		let item00 = list.push(0);
 		let item10 = list.push(10);
 		let item20 = list.push(20);
 		let item30 = list.push(30);
@@ -446,11 +456,12 @@ mod tests {
 		let item27 = insert_tx.push(27);
 		insert_tx.done();
 
-		assert_eq!(item10.order(), Some(0));
-		assert_eq!(item20.order(), Some(1));
-		assert_eq!(item23.order(), Some(2));
-		assert_eq!(item27.order(), Some(3));
-		assert_eq!(item30.order(), Some(4));
+		assert_eq!(item00.order(), Some(0));
+		assert_eq!(item10.order(), Some(1));
+		assert_eq!(item20.order(), Some(2));
+		assert_eq!(item23.order(), Some(3));
+		assert_eq!(item27.order(), Some(4));
+		assert_eq!(item30.order(), Some(5));
 	}
 
 	#[test]

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -1,6 +1,7 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::vec::Vec;
 
 #[derive(Debug)]
 enum EntryOrigin {
@@ -59,16 +60,20 @@ impl<T> From<Entry<T>> for EntryRef<T> {
 }
 
 impl<T> EntryRef<T> {
-	fn read(&self) -> ::std::cell::Ref<Entry<T>> {
+	pub fn read(&self) -> ::std::cell::Ref<Entry<T>> {
 		self.0.borrow()
 	}
 
-	fn write(&self) -> ::std::cell::RefMut<Entry<T>> {
+	pub fn write(&self) -> ::std::cell::RefMut<Entry<T>> {
 		self.0.borrow_mut()
 	}
 
-	fn order(&self) -> Option<usize> {
+	pub fn order(&self) -> Option<usize> {
 		self.0.borrow().order()
+	}
+
+	pub fn link_count(&self) -> usize {
+		Rc::strong_count(&self.0) - 1
 	}
 }
 
@@ -147,6 +152,14 @@ impl<T> RefList<T> {
 
 	pub fn len(&self) -> usize {
 		self.items.len()
+	}
+
+	pub fn clone_ref(&self, idx: usize) -> EntryRef<T> {
+		self.items[idx].clone()
+	}
+
+	pub fn get_ref(&self, idx: usize) -> &EntryRef<T> {
+		&self.items[idx]
 	}
 }
 

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -44,7 +44,7 @@ impl<T> ::std::ops::Deref for Entry<T> {
 	}
 }
 
-struct EntryRef<T>(Rc<RefCell<Entry<T>>>);
+pub struct EntryRef<T>(Rc<RefCell<Entry<T>>>);
 
 impl<T> Clone for EntryRef<T> {
 	fn clone(&self) -> Self {
@@ -72,15 +72,21 @@ impl<T> EntryRef<T> {
 	}
 }
 
-struct RefList<T> {
+pub struct RefList<T> {
 	items: Vec<EntryRef<T>>,
+}
+
+impl<T> Default for RefList<T> {
+	fn default() -> Self {
+		RefList { items: Default::default() }
+	}
 }
 
 impl<T> RefList<T> {
 
-	pub fn new() -> Self { RefList { items: Default::default() } }
+	pub fn new() -> Self { Self::default() }
 
-	fn push(&mut self, t: T) -> EntryRef<T> {
+	pub fn push(&mut self, t: T) -> EntryRef<T> {
 		let idx = self.items.len();
 		let val: EntryRef<_> = Entry::new(t, idx).into();
 		self.items.push(val.clone());
@@ -92,6 +98,10 @@ impl<T> RefList<T> {
 			list: self,
 			deleted: Vec::new(),
 		}
+	}
+
+	pub fn get(&self, idx: usize) -> Option<EntryRef<T>> {
+		self.items.get(idx).cloned()
 	}
 
 	fn done_delete(&mut self, indices: &[usize]) {
@@ -115,12 +125,24 @@ impl<T> RefList<T> {
 		}
 	}
 
-	pub fn delete(&mut self, inddices: &[usize]) {
-		self.done_delete(inddices)
+	pub fn delete(&mut self, indices: &[usize]) {
+		self.done_delete(indices)
 	}
 
 	pub fn delete_one(&mut self, index: usize) {
 		self.done_delete(&[index])
+	}
+
+	pub fn from_slice(list: &[T]) -> Self
+		where T: Clone
+	{
+		let mut res = Self::new();
+
+		for t in list {
+			res.push(t.clone());
+		}
+
+		res
 	}
 }
 

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -16,6 +17,7 @@ impl From<usize> for EntryOrigin {
 	}
 }
 
+/// Reference counting, link-handling object.
 #[derive(Debug)]
 pub struct Entry<T> {
 	val: T,
@@ -23,13 +25,15 @@ pub struct Entry<T> {
 }
 
 impl<T> Entry<T> {
-	fn new(val: T, index: usize) -> Entry<T> {
+	/// New entity.
+	pub fn new(val: T, index: usize) -> Entry<T> {
 		Entry {
 			val: val,
 			index: EntryOrigin::Index(index),
 		}
 	}
 
+	/// Index of the element within the reference list.
 	pub fn order(&self) -> Option<usize> {
 		match self.index {
 			EntryOrigin::Detached => None,
@@ -52,6 +56,8 @@ impl<T> ::std::ops::DerefMut for Entry<T> {
 	}
 }
 
+/// Reference to the entry in the rerence list.
+#[derive(Debug)]
 pub struct EntryRef<T>(Rc<RefCell<Entry<T>>>);
 
 impl<T> Clone for EntryRef<T> {
@@ -67,18 +73,24 @@ impl<T> From<Entry<T>> for EntryRef<T> {
 }
 
 impl<T> EntryRef<T> {
+	/// Read the reference data.
 	pub fn read(&self) -> ::std::cell::Ref<Entry<T>> {
 		self.0.borrow()
 	}
 
+	/// Try to modify internal content of the referenced object.
+	///
+	/// May panic if it is already borrowed.
 	pub fn write(&self) -> ::std::cell::RefMut<Entry<T>> {
 		self.0.borrow_mut()
 	}
 
+	/// Index of the element within the reference list.
 	pub fn order(&self) -> Option<usize> {
 		self.0.borrow().order()
 	}
 
+	/// Number of active links to this entity.
 	pub fn link_count(&self) -> usize {
 		Rc::strong_count(&self.0) - 1
 	}

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -2,6 +2,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::vec::Vec;
+use std::slice;
 
 #[derive(Debug)]
 enum EntryOrigin {
@@ -165,7 +166,7 @@ impl<T> RefList<T> {
 		&self.items[idx]
 	}
 
-	pub fn iter(&self) -> std::slice::Iter<EntryRef<T>> {
+	pub fn iter(&self) -> slice::Iter<EntryRef<T>> {
 		self.items.iter()
 	}
 }

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -110,9 +110,6 @@ impl<T> RefList<T> {
 	}
 
 	fn done_delete(&mut self, indices: &[usize]) {
-
-		let mut index = 0;
-
 		for idx in indices {
 			let mut detached = self.items.remove(*idx);
 			detached.write().index = EntryOrigin::Detached;
@@ -174,13 +171,13 @@ pub struct DeleteTransaction<'a, T> {
 }
 
 impl<'a, T> DeleteTransaction<'a, T> {
-	pub fn push(mut self, idx: usize) -> Self {
+	pub fn push(self, idx: usize) -> Self {
 		let mut tx = self;
 		tx.deleted.push(idx);
 		tx
 	}
 
-	pub fn done(mut self) {
+	pub fn done(self) {
 		let indices = self.deleted;
 		let list = self.list;
 		list.done_delete(&indices[..]);

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -1,0 +1,181 @@
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+#[derive(Debug)]
+enum EntryOrigin {
+	Index(usize),
+	Detached,
+}
+
+impl From<usize> for EntryOrigin {
+	fn from(v: usize) -> Self {
+		EntryOrigin::Index(v)
+	}
+}
+
+#[derive(Debug)]
+pub struct Entry<T> {
+	val: T,
+	index: EntryOrigin,
+}
+
+impl<T> Entry<T> {
+	fn new(val: T, index: usize) -> Entry<T> {
+		Entry {
+			val: val,
+			index: EntryOrigin::Index(index),
+		}
+	}
+
+	pub fn order(&self) -> Option<usize> {
+		match self.index {
+			EntryOrigin::Detached => None,
+			EntryOrigin::Index(idx) => Some(idx),
+		}
+	}
+}
+
+impl<T> ::std::ops::Deref for Entry<T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.val
+	}
+}
+
+struct EntryRef<T>(Rc<RefCell<Entry<T>>>);
+
+impl<T> Clone for EntryRef<T> {
+	fn clone(&self) -> Self {
+		EntryRef(self.0.clone())
+	}
+}
+
+impl<T> From<Entry<T>> for EntryRef<T> {
+	fn from(v: Entry<T>) -> Self {
+		EntryRef(Rc::new(RefCell::new(v)))
+	}
+}
+
+impl<T> EntryRef<T> {
+	fn read(&self) -> ::std::cell::Ref<Entry<T>> {
+		self.0.borrow()
+	}
+
+	fn write(&self) -> ::std::cell::RefMut<Entry<T>> {
+		self.0.borrow_mut()
+	}
+
+	fn order(&self) -> Option<usize> {
+		self.0.borrow().order()
+	}
+}
+
+struct RefList<T> {
+	items: Vec<EntryRef<T>>,
+}
+
+impl<T> RefList<T> {
+
+	pub fn new() -> Self { RefList { items: Default::default() } }
+
+	fn push(&mut self, t: T) -> EntryRef<T> {
+		let idx = self.items.len();
+		let val: EntryRef<_> = Entry::new(t, idx).into();
+		self.items.push(val.clone());
+		val
+	}
+
+	pub fn begin_delete(&mut self) -> DeleteTransaction<T> {
+		DeleteTransaction {
+			list: self,
+			deleted: Vec::new(),
+		}
+	}
+
+	fn done_delete(&mut self, indices: &[usize]) {
+
+		let mut index = 0;
+
+		for idx in indices {
+			let mut detached = self.items.remove(*idx);
+			detached.write().index = EntryOrigin::Detached;
+		}
+
+		for index in 0..self.items.len() {
+			let mut next_entry = self.items.get_mut(index).expect("Checked above; qed").write();
+			let total_less = indices.iter()
+				.take_while(|x| **x < next_entry.order().expect("Items in the list always have order; qed"))
+				.count();
+			match next_entry.index {
+				EntryOrigin::Detached => unreachable!("Items in the list always have order!"),
+				EntryOrigin::Index(ref mut idx) => { *idx -= total_less; },
+			};
+		}
+	}
+
+	pub fn delete(&mut self, inddices: &[usize]) {
+		self.done_delete(inddices)
+	}
+
+	pub fn delete_one(&mut self, index: usize) {
+		self.done_delete(&[index])
+	}
+}
+
+#[must_use]
+pub struct DeleteTransaction<'a, T> {
+	list: &'a mut RefList<T>,
+	deleted: Vec<usize>,
+}
+
+impl<'a, T> DeleteTransaction<'a, T> {
+	pub fn push(mut self, idx: usize) -> Self {
+		let mut tx = self;
+		tx.deleted.push(idx);
+		tx
+	}
+
+	pub fn done(mut self) {
+		let indices = self.deleted;
+		let list = self.list;
+		list.done_delete(&indices[..]);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	fn order() {
+		let mut list = RefList::<u32>::new();
+		let item10 = list.push(10);
+		let item20 = list.push(20);
+		let item30 = list.push(30);
+
+		assert_eq!(item10.order(), Some(0usize));
+		assert_eq!(item20.order(), Some(1));
+		assert_eq!(item30.order(), Some(2));
+
+		assert_eq!(**item10.read(), 10);
+		assert_eq!(**item20.read(), 20);
+		assert_eq!(**item30.read(), 30);
+	}
+
+	#[test]
+	fn delete() {
+		let mut list = RefList::<u32>::new();
+		let item10 = list.push(10);
+		let item20 = list.push(20);
+		let item30 = list.push(30);
+
+		list.begin_delete().push(1).done();
+
+		assert_eq!(item10.order(), Some(0));
+		assert_eq!(item30.order(), Some(1));
+		assert_eq!(item20.order(), None);
+	}
+}

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -161,6 +161,10 @@ impl<T> RefList<T> {
 	pub fn get_ref(&self, idx: usize) -> &EntryRef<T> {
 		&self.items[idx]
 	}
+
+	pub fn iter(&self) -> std::slice::Iter<EntryRef<T>> {
+		self.items.iter()
+	}
 }
 
 #[must_use]

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -167,7 +167,11 @@ impl<T> RefList<T> {
 	pub fn begin_insert_after<F>(&mut self, mut f: F) -> InsertTransaction<T>
 		where F : FnMut(&T) -> bool
 	{
-		let pos = self.items.iter().position(|rf| f(&**rf.read())).map(|x| x + 1).unwrap_or(self.items.len());
+		let pos = self
+			.items.iter()
+			.position(|rf| f(&**rf.read())).map(|x| x + 1)
+			.unwrap_or(self.items.len());
+
 		self.begin_insert(pos)
 	}
 
@@ -209,7 +213,6 @@ impl<T> RefList<T> {
 			detached.write().index = EntryOrigin::Detached;
 			total_removed += 1;
 		}
-
 	}
 
 	fn done_insert(&mut self, index: usize, mut items: Vec<EntryRef<T>>) {

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -144,6 +144,10 @@ impl<T> RefList<T> {
 
 		res
 	}
+
+	pub fn len(&self) -> usize {
+		self.items.len()
+	}
 }
 
 #[must_use]

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -45,6 +45,12 @@ impl<T> ::std::ops::Deref for Entry<T> {
 	}
 }
 
+impl<T> ::std::ops::DerefMut for Entry<T> {
+	fn deref_mut(&mut self) -> &mut T {
+		&mut self.val
+	}
+}
+
 pub struct EntryRef<T>(Rc<RefCell<Entry<T>>>);
 
 impl<T> Clone for EntryRef<T> {

--- a/src/ref_list.rs
+++ b/src/ref_list.rs
@@ -196,12 +196,12 @@ impl<T> RefList<T> {
 	}
 
 	fn done_delete(&mut self, indices: &[usize]) {
-		for index in 0..self.items.len() {
-			let mut next_entry = self.items.get_mut(index).expect("Checked above; qed").write();
+		for mut entry in self.items.iter_mut() {
+			let mut entry = entry.write();
 			let total_less = indices.iter()
-				.take_while(|x| **x < next_entry.order().expect("Items in the list always have order; qed"))
+				.take_while(|x| **x < entry.order().expect("Items in the list always have order; qed"))
 				.count();
-			match next_entry.index {
+			match entry.index {
 				EntryOrigin::Detached => unreachable!("Items in the list always have order!"),
 				EntryOrigin::Index(ref mut idx) => { *idx -= total_less; },
 			};

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -30,6 +30,7 @@ fn validate_wasm(binary: &[u8]) -> Result<(), wabt::Error> {
 }
 
 fn run_diff_test<F: FnOnce(&[u8]) -> Vec<u8>>(test_dir: &str, name: &str, test: F) {
+	// FIXME: not going to work on windows?
 	let mut fixture_path = PathBuf::from(concat!(
 		env!("CARGO_MANIFEST_DIR"),
 		"/tests/fixtures/",
@@ -37,6 +38,7 @@ fn run_diff_test<F: FnOnce(&[u8]) -> Vec<u8>>(test_dir: &str, name: &str, test: 
 	fixture_path.push(test_dir);
 	fixture_path.push(name);
 
+	// FIXME: not going to work on windows?
 	let mut expected_path = PathBuf::from(concat!(
 		env!("CARGO_MANIFEST_DIR"),
 		"/tests/expectations/"


### PR DESCRIPTION
This introduced a new way to transform and build wasm binaries via the high (medium?) level representation of the format. 

Currently, all over the repository, we use `parity-wasm` for manipulating wasm binaries. This is awkward, error-prone and requires an enormous amount of testing.

With this API, it will be much easier (see tests and examples).

- [x] some docs
- [x] much more tests
- [ ] ~~use latest parity-wasm?~~ following pr for the whole code base
- [x] no panics
- [x] examples
- [ ] ~~move to general-purpose crate?~~ later
- [ ] ~~name mapping?~~ later