### PR TITLE
Preserve 'deploy' export for Substrate binaries

### DIFF
--- a/cli/pack/main.rs
+++ b/cli/pack/main.rs
@@ -31,7 +31,7 @@ fn main() {
     // Invoke packer
     let mut result_module = utils::pack_instance(raw_module, ctor_module, &utils::TargetRuntime::pwasm()).expect("Packing failed");
     // Optimize constructor, since it does not need everything
-    utils::optimize(&mut result_module, vec![target_runtime.call_symbol]).expect("Optimization failed");
+    utils::optimize(&mut result_module, vec![target_runtime.symbols().call]).expect("Optimization failed");
 
     parity_wasm::serialize_to_file(&output, result_module).expect("Serialization failed");
 }

--- a/cli/prune/main.rs
+++ b/cli/prune/main.rs
@@ -24,12 +24,12 @@ fn main() {
                             .short("e")
                             .takes_value(true)
                             .value_name("functions")
-                            .help(&format!("Comma-separated list of exported functions to keep. Default: '{}'", target_runtime.call_symbol)))
+                            .help(&format!("Comma-separated list of exported functions to keep. Default: '{}'", target_runtime.symbols().call)))
                         .get_matches();
 
     let exports = matches
                     .value_of("exports")
-                    .unwrap_or(target_runtime.call_symbol)
+                    .unwrap_or(target_runtime.symbols().call)
                     .split(',')
                     .collect();
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for Error {
 
 fn has_ctor(module: &elements::Module, target_runtime: &TargetRuntime) -> bool {
 	if let Some(ref section) = module.export_section() {
-		section.entries().iter().any(|e| target_runtime.create_symbol == e.field())
+		section.entries().iter().any(|e| target_runtime.symbols().create == e.field())
 	} else {
 		false
 	}
@@ -94,7 +94,7 @@ pub fn build(
 	let mut ctor_module = module.clone();
 
 	let mut public_api_entries = public_api_entries.to_vec();
-	public_api_entries.push(target_runtime.call_symbol);
+	public_api_entries.push(target_runtime.symbols().call);
 	if !skip_optimization {
 		optimize(
 			&mut module,
@@ -104,7 +104,7 @@ pub fn build(
 
 	if has_ctor(&ctor_module, target_runtime) {
 		if !skip_optimization {
-			optimize(&mut ctor_module, vec![target_runtime.create_symbol])?;
+			optimize(&mut ctor_module, vec![target_runtime.symbols().create])?;
 		}
 		let ctor_module = pack_instance(
 			parity_wasm::serialize(module.clone()).map_err(Error::Encoding)?,

--- a/src/build.rs
+++ b/src/build.rs
@@ -102,17 +102,21 @@ pub fn build(
 		)?;
 	}
 
-	if has_ctor(&ctor_module, target_runtime) {
-		if !skip_optimization {
-			optimize(&mut ctor_module, vec![target_runtime.symbols().create])?;
-		}
-		let ctor_module = pack_instance(
+	if !has_ctor(&ctor_module, target_runtime) {
+		return Ok((module, None))
+	}
+
+	if !skip_optimization {
+		optimize(&mut ctor_module, vec![target_runtime.symbols().create])?;
+	}
+
+	if let TargetRuntime::PWasm(_) = target_runtime {
+		ctor_module = pack_instance(
 			parity_wasm::serialize(module.clone()).map_err(Error::Encoding)?,
 			ctor_module.clone(),
 			target_runtime,
 		)?;
-		Ok((module, Some(ctor_module)))
-	} else {
-		Ok((module, None))
 	}
+
+	Ok((module, Some(ctor_module)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,59 +5,76 @@
 #[macro_use]
 extern crate alloc;
 
-extern crate parity_wasm;
 extern crate byteorder;
-#[macro_use] extern crate log;
+extern crate parity_wasm;
+#[macro_use]
+extern crate log;
 
 pub mod rules;
 
 mod build;
-mod optimizer;
-mod gas;
-mod symbols;
 mod ext;
+mod gas;
+mod optimizer;
 mod pack;
 mod runtime_type;
+mod symbols;
 
 pub mod stack_height;
 
-pub use build::{build, SourceTarget, Error as BuildError};
-pub use optimizer::{optimize, Error as OptimizerError};
+pub use build::{build, Error as BuildError, SourceTarget};
+pub use ext::{
+    externalize, externalize_mem, shrink_unknown_stack, underscore_funcs, ununderscore_funcs,
+};
 pub use gas::inject_gas_counter;
-pub use ext::{externalize, externalize_mem, underscore_funcs, ununderscore_funcs, shrink_unknown_stack};
+pub use optimizer::{optimize, Error as OptimizerError};
 pub use pack::{pack_instance, Error as PackingError};
 pub use runtime_type::inject_runtime_type;
 
-pub struct TargetRuntime {
-	pub create_symbol: &'static str,
-	pub call_symbol: &'static str,
-	pub return_symbol: &'static str,
+pub struct TargetSymbols {
+    pub create: &'static str,
+    pub call: &'static str,
+    pub return_: &'static str,
+}
+
+pub enum TargetRuntime {
+    Substrate(TargetSymbols),
+    PWasm(TargetSymbols),
 }
 
 impl TargetRuntime {
-	pub fn substrate() -> TargetRuntime {
-		TargetRuntime {
-			create_symbol: "deploy",
-			call_symbol: "call",
-			return_symbol: "ext_return",
-		}
-	}
 
-	pub fn pwasm() -> TargetRuntime {
-		TargetRuntime {
-			create_symbol: "deploy",
-			call_symbol: "call",
-			return_symbol: "ret",
+    pub fn substrate() -> TargetRuntime {
+        TargetRuntime::Substrate(TargetSymbols {
+            create: "deploy",
+            call: "call",
+            return_: "ext_return",
+        })
+    }
+
+    pub fn pwasm() -> TargetRuntime {
+        TargetRuntime::PWasm(TargetSymbols {
+            create: "deploy",
+            call: "call",
+            return_: "ret",
+        })
+    }
+
+    pub fn symbols(&self) -> &TargetSymbols {
+        match self {
+			TargetRuntime::Substrate(s) => s,
+			TargetRuntime::PWasm(s) => s,
 		}
-	}
+    }
+
 }
 
 #[cfg(not(feature = "std"))]
 mod std {
-	pub use core::*;
-	pub use alloc::{vec, string, boxed, borrow};
+    pub use alloc::{borrow, boxed, string, vec};
+    pub use core::*;
 
-	pub mod collections {
-		pub use alloc::collections::{BTreeMap, BTreeSet};
-	}
+    pub mod collections {
+        pub use alloc::collections::{BTreeMap, BTreeSet};
+    }
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -195,10 +195,6 @@ pub fn pack_instance(raw_module: Vec<u8>, mut ctor_module: elements::Module, tar
             ])).build()
             .build()
         .build();
-    
-    if let TargetRuntime::Substrate(_) = target {
-        return Ok(new_module)
-    }
 
     for section in new_module.sections_mut() {
         if let &mut Section::Export(ref mut export_section) = section {


### PR DESCRIPTION
Closes #108 

Don't rename create symbol for substrate ctor binaries
Refactor TargetRuntime as enum
