### PR TITLE
Preserve deploy symbol on optimize for substrate target

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -96,10 +96,7 @@ pub fn build(
 	let mut public_api_entries = public_api_entries.to_vec();
 	public_api_entries.push(target_runtime.symbols().call);
 	if !skip_optimization {
-		optimize(
-			&mut module,
-			public_api_entries,
-		)?;
+		optimize(&mut module, public_api_entries)?;
 	}
 
 	if !has_ctor(&ctor_module, target_runtime) {
@@ -107,7 +104,11 @@ pub fn build(
 	}
 
 	if !skip_optimization {
-		optimize(&mut ctor_module, vec![target_runtime.symbols().create])?;
+		let preserved_exports = match target_runtime {
+			TargetRuntime::PWasm(_) => vec![target_runtime.symbols().call],
+			TargetRuntime::Substrate(_) => vec![target_runtime.symbols().call, target_runtime.symbols().create],
+		};
+		optimize(&mut ctor_module, preserved_exports)?;
 	}
 
 	if let TargetRuntime::PWasm(_) = target_runtime {

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -41,7 +41,7 @@ impl fmt::Display for Error {
     }
 }
 
-/// If module has an exported function matching "create" symbol we want to pack it into "constructor".
+/// If a pwasm module has an exported function matching "create" symbol we want to pack it into "constructor".
 /// `raw_module` is the actual contract code
 /// `ctor_module` is the constructor which should return `raw_module`
 pub fn pack_instance(raw_module: Vec<u8>, mut ctor_module: elements::Module, target: &TargetRuntime) -> Result<elements::Module, Error> {


### PR DESCRIPTION
Changes in #109 didn't address `optimize()` behaviour which can "optimize" away the `deploy` export