### PR TITLE
Rewrite gas metering algorithm to handle branches

### DIFF
--- a/src/gas.rs
+++ b/src/gas.rs
@@ -914,4 +914,40 @@ mod tests {
 				(get_global 0)))
 		"#
 	}
+
+	test_gas_counter_injection! {
+		name = branch_from_if_not_else;
+		input = r#"
+		(module
+			(func (result i32)
+				(get_global 0)
+				(block
+					(get_global 0)
+					(if
+						(then (br 1))
+						(else (br 0)))
+					(get_global 0)
+					(drop))
+				(get_global 0)))
+		"#;
+		expected = r#"
+		(module
+			(func (result i32)
+				(call 0 (i32.const 5))
+				(get_global 0)
+				(block
+					(get_global 0)
+					(if
+						(then
+							(call 0 (i32.const 1))
+							(br 1))
+						(else
+							(call 0 (i32.const 1))
+							(br 0)))
+					(call 0 (i32.const 2))
+					(get_global 0)
+					(drop))
+				(get_global 0)))
+		"#
+	}
 }

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -342,6 +342,14 @@ mod tests {
 	use super::*;
 	use rules;
 
+	fn get_function_body(module: &elements::Module, index: usize)
+		-> Option<&[elements::Instruction]>
+	{
+		module.code_section()
+			.and_then(|code_section| code_section.bodies().get(index))
+			.map(|func_body| func_body.code().elements())
+	}
+
 	#[test]
 	fn simple_grow() {
 		use parity_wasm::elements::Instruction::*;
@@ -367,18 +375,17 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &rules::Set::default().with_grow_cost(10000)).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
 				I32Const(3),
 				Call(0),
 				GetGlobal(0),
 				Call(2),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[0]
-				.code().elements()
+			][..]
 		);
 		assert_eq!(
+			get_function_body(&injected_module, 1).unwrap(),
 			&vec![
 				GetLocal(0),
 				GetLocal(0),
@@ -387,10 +394,7 @@ mod tests {
 				Call(0),
 				GrowMemory(0),
 				End,
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[1]
-				.code().elements()
+			][..]
 		);
 
 		let binary = serialize(injected_module).expect("serialization failed");
@@ -422,16 +426,14 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &rules::Set::default()).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
 				I32Const(3),
 				Call(0),
 				GetGlobal(0),
 				GrowMemory(0),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[0]
-				.code().elements()
+			][..]
 		);
 
 		assert_eq!(injected_module.functions_space(), 2);
@@ -464,15 +466,13 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &Default::default()).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
 				I32Const(2),
 				Call(0),
 				GetGlobal(0),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[0]
-				.code().elements()
+			][..]
 		);
 	}
 
@@ -506,6 +506,7 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &Default::default()).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
 				I32Const(4),
 				Call(0),
@@ -519,10 +520,7 @@ mod tests {
 				End,
 				GetGlobal(0),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[0]
-				.code().elements()
+			][..]
 		);
 	}
 
@@ -559,6 +557,7 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &Default::default()).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
 				I32Const(4),
 				Call(0),
@@ -577,10 +576,7 @@ mod tests {
 				End,
 				GetGlobal(0),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[0]
-				.code().elements()
+			][..]
 		);
 	}
 
@@ -621,6 +617,7 @@ mod tests {
 		let injected_module = inject_gas_counter(module, &Default::default()).unwrap();
 
 		assert_eq!(
+			get_function_body(&injected_module, 1).unwrap(),
 			&vec![
 				I32Const(4),
 				Call(0),
@@ -639,10 +636,7 @@ mod tests {
 				End,
 				Call(1),
 				End
-			][..],
-			injected_module
-				.code_section().expect("function section should exist").bodies()[1]
-				.code().elements()
+			][..]
 		);
 	}
 

--- a/tests/expectations/gas/branch.wat
+++ b/tests/expectations/gas/branch.wat
@@ -4,11 +4,9 @@
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0) (result i32)
     (local i32 i32)
-    i32.const 3
+    i32.const 13
     call 0
     block  ;; label = @1
-      i32.const 17
-      call 0
       i32.const 0
       set_local 0
       i32.const 1
@@ -20,6 +18,8 @@
       set_local 1
       i32.const 1
       br_if 0 (;@1;)
+      i32.const 5
+      call 0
       get_local 0
       get_local 1
       tee_local 0

--- a/tests/expectations/gas/call.wat
+++ b/tests/expectations/gas/call.wat
@@ -4,7 +4,7 @@
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0) (param i32 i32) (result i32)
     (local i32)
-    i32.const 6
+    i32.const 5
     call 0
     get_local 0
     get_local 1
@@ -12,7 +12,7 @@
     set_local 2
     get_local 2)
   (func (;2;) (type 0) (param i32 i32) (result i32)
-    i32.const 4
+    i32.const 3
     call 0
     get_local 0
     get_local 1

--- a/tests/expectations/gas/ifs.wat
+++ b/tests/expectations/gas/ifs.wat
@@ -3,17 +3,17 @@
   (type (;1;) (func (param i32)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0) (param i32) (result i32)
-    i32.const 3
+    i32.const 2
     call 0
     i32.const 1
     if (result i32)  ;; label = @1
-      i32.const 4
+      i32.const 3
       call 0
       get_local 0
       i32.const 1
       i32.add
     else
-      i32.const 3
+      i32.const 2
       call 0
       get_local 0
       i32.popcnt

--- a/tests/expectations/gas/simple.wat
+++ b/tests/expectations/gas/simple.wat
@@ -3,24 +3,22 @@
   (type (;1;) (func (param i32)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0)
-    i32.const 3
+    i32.const 2
     call 0
     i32.const 1
     if  ;; label = @1
-      i32.const 2
+      i32.const 1
       call 0
       loop  ;; label = @2
-        i32.const 3
+        i32.const 2
         call 0
         i32.const 123
         drop
       end
     end)
   (func (;2;) (type 0)
-    i32.const 2
+    i32.const 1
     call 0
     block  ;; label = @1
-      i32.const 1
-      call 0
     end)
   (export "simple" (func 1)))

--- a/tests/expectations/gas/start.wat
+++ b/tests/expectations/gas/start.wat
@@ -6,15 +6,13 @@
   (import "env" "memory" (memory (;0;) 1 1))
   (import "env" "gas" (func (;1;) (type 2)))
   (func (;2;) (type 1)
-    i32.const 5
+    i32.const 4
     call 1
     i32.const 8
     i32.const 4
     call 0
     unreachable)
-  (func (;3;) (type 1)
-    i32.const 1
-    call 1)
+  (func (;3;) (type 1))
   (export "call" (func 3))
   (start 2)
   (data (i32.const 8) "\01\02\03\04"))


### PR DESCRIPTION
Partial fix for #120. This handles `br*` instructions but not diverging external calls yet.

The most noticeable change for most contracts will be that this removes the extra 1 gas cost for entering a new block. Note that `block`, `loop`, and `if` instructions still contribute a gas cost from the given `rules::Set`. Previously, on top of this, there was an additional 1 gas charged in each call to charge gas.