### PR TITLE
Preserve "deploy" when optimizing pwasm ctor module

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -105,7 +105,7 @@ pub fn build(
 
 	if !skip_optimization {
 		let preserved_exports = match target_runtime {
-			TargetRuntime::PWasm(_) => vec![target_runtime.symbols().call],
+			TargetRuntime::PWasm(_) => vec![target_runtime.symbols().create],
 			TargetRuntime::Substrate(_) => vec![target_runtime.symbols().call, target_runtime.symbols().create],
 		};
 		optimize(&mut ctor_module, preserved_exports)?;


### PR DESCRIPTION
When optimizing the constructor module for a PWasm contract the "deploy" symbol is preserved instead of the "call" symbol. Before this change `build` would error for PWasm contracts because `pack_instance` would not find the "deploy" symbol in the optimized contract.

Fixes #128