### PR TITLE
Update wabt package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3"
-wabt = "0.2"
+wabt = "0.9"
 diff = "0.1.11"
 indoc = "0.3"
 rand = "0.7"

--- a/tests/expectations/gas/branch.wat
+++ b/tests/expectations/gas/branch.wat
@@ -8,22 +8,22 @@
     call 0
     block  ;; label = @1
       i32.const 0
-      set_local 0
+      local.set 0
       i32.const 1
-      set_local 1
-      get_local 0
-      get_local 1
-      tee_local 0
+      local.set 1
+      local.get 0
+      local.get 1
+      local.tee 0
       i32.add
-      set_local 1
+      local.set 1
       i32.const 1
       br_if 0 (;@1;)
       i32.const 5
       call 0
-      get_local 0
-      get_local 1
-      tee_local 0
+      local.get 0
+      local.get 1
+      local.tee 0
       i32.add
-      set_local 1
+      local.set 1
     end
-    get_local 1))
+    local.get 1))

--- a/tests/expectations/gas/call.wat
+++ b/tests/expectations/gas/call.wat
@@ -6,14 +6,14 @@
     (local i32)
     i32.const 5
     call 0
-    get_local 0
-    get_local 1
+    local.get 0
+    local.get 1
     call 2
-    set_local 2
-    get_local 2)
+    local.set 2
+    local.get 2)
   (func (;2;) (type 0) (param i32 i32) (result i32)
     i32.const 3
     call 0
-    get_local 0
-    get_local 1
+    local.get 0
+    local.get 1
     i32.add))

--- a/tests/expectations/gas/ifs.wat
+++ b/tests/expectations/gas/ifs.wat
@@ -9,12 +9,12 @@
     if (result i32)  ;; label = @1
       i32.const 3
       call 0
-      get_local 0
+      local.get 0
       i32.const 1
       i32.add
     else
       i32.const 2
       call 0
-      get_local 0
+      local.get 0
       i32.popcnt
     end))

--- a/tests/expectations/gas/start.wat
+++ b/tests/expectations/gas/start.wat
@@ -15,4 +15,4 @@
   (func (;3;) (type 1))
   (export "call" (func 3))
   (start 2)
-  (data (i32.const 8) "\01\02\03\04"))
+  (data (;0;) (i32.const 8) "\01\02\03\04"))

--- a/tests/expectations/stack-height/global.wat
+++ b/tests/expectations/stack-height/global.wat
@@ -4,52 +4,52 @@
   (type (;2;) (func (param i32)))
   (import "env" "foo" (func (;0;) (type 0)))
   (func (;1;) (type 1) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
+    local.get 0
+    local.get 1
     i32.add)
   (func (;2;) (type 2) (param i32)
     (local i32)
-    get_global 0
+    global.get 0
     i32.const 1
     i32.add
-    tee_local 1
-    set_global 0
-    get_local 1
-    get_local 0
-    get_global 1
+    local.tee 1
+    global.set 0
+    local.get 1
+    local.get 0
+    global.get 1
     i32.const 2
     i32.add
-    set_global 1
-    get_global 1
+    global.set 1
+    global.get 1
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 1
-    get_global 1
+    global.get 1
     i32.const 2
     i32.sub
-    set_global 1
+    global.set 1
     drop)
   (func (;3;) (type 1) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
-    get_global 1
+    local.get 0
+    local.get 1
+    global.get 1
     i32.const 2
     i32.add
-    set_global 1
-    get_global 1
+    global.set 1
+    global.get 1
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 1
-    get_global 1
+    global.get 1
     i32.const 2
     i32.sub
-    set_global 1)
+    global.set 1)
   (global (;0;) (mut i32) (i32.const 1))
   (global (;1;) (mut i32) (i32.const 0))
   (export "i32.add" (func 3)))

--- a/tests/expectations/stack-height/imports.wat
+++ b/tests/expectations/stack-height/imports.wat
@@ -6,26 +6,26 @@
   (func (;2;) (type 1) (param i32 i32) (result i32)
     call 0
     call 1
-    get_local 0
-    get_local 1
+    local.get 0
+    local.get 1
     i32.add)
   (func (;3;) (type 1) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
-    get_global 0
+    local.get 0
+    local.get 1
+    global.get 0
     i32.const 2
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 2
-    get_global 0
+    global.get 0
     i32.const 2
     i32.sub
-    set_global 0)
+    global.set 0)
   (global (;0;) (mut i32) (i32.const 0))
   (export "i32.add" (func 3)))

--- a/tests/expectations/stack-height/simple.wat
+++ b/tests/expectations/stack-height/simple.wat
@@ -4,20 +4,20 @@
     i32.const 123
     drop)
   (func (;1;) (type 0)
-    get_global 0
+    global.get 0
     i32.const 1
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 0
-    get_global 0
+    global.get 0
     i32.const 1
     i32.sub
-    set_global 0)
+    global.set 0)
   (global (;0;) (mut i32) (i32.const 0))
   (export "simple" (func 1)))

--- a/tests/expectations/stack-height/start.wat
+++ b/tests/expectations/stack-height/start.wat
@@ -7,37 +7,37 @@
     (local i32))
   (func (;2;) (type 1))
   (func (;3;) (type 1)
-    get_global 0
+    global.get 0
     i32.const 1
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 1
-    get_global 0
+    global.get 0
     i32.const 1
     i32.sub
-    set_global 0)
+    global.set 0)
   (func (;4;) (type 1)
-    get_global 0
+    global.get 0
     i32.const 1
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 1
-    get_global 0
+    global.get 0
     i32.const 1
     i32.sub
-    set_global 0)
+    global.set 0)
   (global (;0;) (mut i32) (i32.const 0))
   (export "exported_start" (func 4))
   (export "call" (func 2))

--- a/tests/expectations/stack-height/table.wat
+++ b/tests/expectations/stack-height/table.wat
@@ -4,82 +4,82 @@
   (type (;2;) (func (param i32 i32) (result i32)))
   (import "env" "foo" (func (;0;) (type 0)))
   (func (;1;) (type 1) (param i32)
-    get_local 0
+    local.get 0
     i32.const 0
-    get_global 0
+    global.get 0
     i32.const 2
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 2
-    get_global 0
+    global.get 0
     i32.const 2
     i32.sub
-    set_global 0
+    global.set 0
     drop)
   (func (;2;) (type 2) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
+    local.get 0
+    local.get 1
     i32.add)
   (func (;3;) (type 2) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
-    get_global 0
+    local.get 0
+    local.get 1
+    global.get 0
     i32.const 2
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 2
-    get_global 0
+    global.get 0
     i32.const 2
     i32.sub
-    set_global 0)
+    global.set 0)
   (func (;4;) (type 1) (param i32)
-    get_local 0
-    get_global 0
+    local.get 0
+    global.get 0
     i32.const 2
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 1
-    get_global 0
+    global.get 0
     i32.const 2
     i32.sub
-    set_global 0)
+    global.set 0)
   (func (;5;) (type 2) (param i32 i32) (result i32)
-    get_local 0
-    get_local 1
-    get_global 0
+    local.get 0
+    local.get 1
+    global.get 0
     i32.const 2
     i32.add
-    set_global 0
-    get_global 0
+    global.set 0
+    global.get 0
     i32.const 1024
     i32.gt_u
     if  ;; label = @1
       unreachable
     end
     call 2
-    get_global 0
+    global.get 0
     i32.const 2
     i32.sub
-    set_global 0)
-  (table (;0;) 10 anyfunc)
+    global.set 0)
+  (table (;0;) 10 funcref)
   (global (;0;) (mut i32) (i32.const 0))
   (export "i32.add" (func 5))
-  (elem (i32.const 0) 0 4 5))
+  (elem (;0;) (i32.const 0) 0 4 5))


### PR DESCRIPTION
Update `wabt` from 0.2 to 0.9 and with it `wabt-sys`. Old versions of `wabt-sys` failed to compile with newer versions of gcc.

The change also requires and update to the WebAssembly text format.