### PR TITLE
Bump 'parity-wasm' version to enable no_std builds on stable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rust:
 script:
   - cargo build --all --release --verbose
   - cargo test --all --verbose
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features; fi
+  - cargo build --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwasm-utils"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -10,7 +10,7 @@ keywords = ["wasm", "webassembly", "pwasm"]
 [dependencies]
 # If you add the feature "bulk", make sure you fixed all expects that say
 # "parity-wasm is compiled without bulk-memory operations"
-parity-wasm = { version = "0.40.1", default-features = false }
+parity-wasm = { version = "0.41.0", default-features = false }
 log = { version = "0.4", default-features = false }
 byteorder = { version = "1", default-features = false }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwasm-utils-cli"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -38,8 +38,8 @@ name = "wasm-check"
 path = "check/main.rs"
 
 [dependencies]
-parity-wasm = "0.40.1"
-pwasm-utils = { path = "..", version = "0.11" }
+parity-wasm = "0.41.0"
+pwasm-utils = { path = "..", version = "0.12" }
 glob = "0.2"
 clap = "2.24"
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]


### PR DESCRIPTION
I hope this change makes it onto crates.io so I've taken the liberty of bumping the crate version in preparation for cargo publish.

Changes:

- Remove #![cfg_attr(not(feature = "std"), feature(alloc))] (alloc feature is stable now)
- Bump 'parity-wasm' version to enable no_std builds on stable.
- Bump own version in preparation for cargo publish.
- Bump cli version to match.
- Update travis-ci to test no_std builds event when compiling on stable.