### PR TITLE
Fix issues with the stack height metering

### DIFF
--- a/cli/build/main.rs
+++ b/cli/build/main.rs
@@ -230,7 +230,7 @@ mod tests {
 
 			let wasm_path = target_path.join("example_wasm.wasm");
 			let mut f = fs::File::create(wasm_path).expect("create fail failed");
-			f.write(b"\0asm").expect("write file failed");
+			f.write_all(b"\0asm").expect("write file failed");
 		}
 
 		let path = tmp_dir.path().to_string_lossy();

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -288,6 +288,9 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 					.get(x as usize)
 					.ok_or_else(|| Error("Type not found".into()))?;
 
+				// Pop the offset into the function table.
+				stack.pop_values(1)?;
+
 				// Pop values for arguments of the function.
 				stack.pop_values(ty.params().len() as u32)?;
 
@@ -522,5 +525,29 @@ mod tests {
 
 		let height = compute(0, &module).unwrap();
 		assert_eq!(height, 2);
+	}
+
+	#[test]
+	fn call_indirect() {
+		let module = parse_wat(
+			r#"
+(module
+	(table $ptr 1 1 funcref)
+	(elem $ptr (i32.const 0) func 1)
+	(func $main
+		(call_indirect (i32.const 0))
+		(call_indirect (i32.const 0))
+		(call_indirect (i32.const 0))
+	)
+	(func $callee
+		i64.const 42
+		drop
+	)
+)
+"#,
+		);
+
+		let height = compute(0, &module).unwrap();
+		assert_eq!(height, 1);
 	}
 }

--- a/tests/expectations/stack-height/start.wat
+++ b/tests/expectations/stack-height/start.wat
@@ -22,23 +22,7 @@
     i32.const 1
     i32.sub
     global.set 0)
-  (func (;4;) (type 1)
-    global.get 0
-    i32.const 1
-    i32.add
-    global.set 0
-    global.get 0
-    i32.const 1024
-    i32.gt_u
-    if  ;; label = @1
-      unreachable
-    end
-    call 1
-    global.get 0
-    i32.const 1
-    i32.sub
-    global.set 0)
   (global (;0;) (mut i32) (i32.const 0))
-  (export "exported_start" (func 4))
+  (export "exported_start" (func 3))
   (export "call" (func 2))
-  (start 4))
+  (start 3))

--- a/tests/expectations/stack-height/table.wat
+++ b/tests/expectations/stack-height/table.wat
@@ -26,25 +26,7 @@
     local.get 0
     local.get 1
     i32.add)
-  (func (;3;) (type 2) (param i32 i32) (result i32)
-    local.get 0
-    local.get 1
-    global.get 0
-    i32.const 2
-    i32.add
-    global.set 0
-    global.get 0
-    i32.const 1024
-    i32.gt_u
-    if  ;; label = @1
-      unreachable
-    end
-    call 2
-    global.get 0
-    i32.const 2
-    i32.sub
-    global.set 0)
-  (func (;4;) (type 1) (param i32)
+  (func (;3;) (type 1) (param i32)
     local.get 0
     global.get 0
     i32.const 2
@@ -61,7 +43,7 @@
     i32.const 2
     i32.sub
     global.set 0)
-  (func (;5;) (type 2) (param i32 i32) (result i32)
+  (func (;4;) (type 2) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     global.get 0
@@ -81,5 +63,5 @@
     global.set 0)
   (table (;0;) 10 funcref)
   (global (;0;) (mut i32) (i32.const 0))
-  (export "i32.add" (func 5))
-  (elem (;0;) (i32.const 0) func 0 4 5))
+  (export "i32.add" (func 4))
+  (elem (;0;) (i32.const 0) func 0 3 4))


### PR DESCRIPTION
This PR fixes these two issues with the stack height metering:

1. `CallIndirect` handling did not consider that it pops one argument from the stack.
2. The stack height metering inserts superfluous thunks.

Regarding the redundant thunks:
The fix even simplifies the code by removing a, in my opinion, redundant `Vec`. I am not sure why it was there in the first place. Maybe some borrow checker workaround? Or maybe there is another reason that I overlooked?