### PR TITLE
Address all clippy lints

### DIFF
--- a/cli/build/main.rs
+++ b/cli/build/main.rs
@@ -28,12 +28,12 @@ pub enum Error {
 impl std::fmt::Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
 		use self::Error::*;
-		match *self {
-			Io(ref io) => write!(f, "Generic i/o error: {}", io),
-			FailedToCopy(ref msg) => write!(f, "{}. Have you tried to run \"cargo build\"?", msg),
-			Decoding(ref err, ref file) => write!(f, "Decoding error ({}). Must be a valid wasm file {}. Pointed wrong file?", err, file),
-			Encoding(ref err) => write!(f, "Encoding error ({}). Almost impossible to happen, no free disk space?", err),
-			Build(ref err) => write!(f, "Build error: {}", err)
+		match self {
+			Io(io) => write!(f, "Generic i/o error: {}", io),
+			FailedToCopy(msg) => write!(f, "{}. Have you tried to run \"cargo build\"?", msg),
+			Decoding(err, file) => write!(f, "Decoding error ({}). Must be a valid wasm file {}. Pointed wrong file?", err, file),
+			Encoding(err) => write!(f, "Encoding error ({}). Almost impossible to happen, no free disk space?", err),
+			Build(err) => write!(f, "Build error: {}", err)
 		}
 	}
 }
@@ -163,9 +163,9 @@ fn do_main() -> Result<(), Error> {
 		None
 	};
 
-	let public_api_entries = matches.value_of("public_api")
-		.map(|val| val.split(",").collect())
-		.unwrap_or(Vec::new());
+	let public_api_entries: Vec<_> = matches.value_of("public_api")
+		.map(|val| val.split(',').collect())
+		.unwrap_or_default();
 
 	let target_runtime = match matches.value_of("target-runtime").expect("target-runtime has a default value; qed") {
 		"pwasm" => TargetRuntime::pwasm(),

--- a/cli/build/source.rs
+++ b/cli/build/source.rs
@@ -17,8 +17,8 @@ pub struct SourceInput<'a> {
 impl<'a> SourceInput<'a> {
 	pub fn new<'b>(target_dir: &'b str, bin_name: &'b str) -> SourceInput<'b> {
 		SourceInput {
-			target_dir: target_dir,
-			bin_name: bin_name,
+			target_dir,
+			bin_name,
 			final_name: bin_name,
 			target: SourceTarget::Emscripten,
 		}

--- a/cli/check/main.rs
+++ b/cli/check/main.rs
@@ -11,7 +11,7 @@ fn fail(msg: &str) -> ! {
 	std::process::exit(1)
 }
 
-const ALLOWED_IMPORTS: &'static [&'static str] = &[
+const ALLOWED_IMPORTS: &[&str] = &[
 	"ret",
 	"storage_read",
 	"storage_write",
@@ -54,14 +54,14 @@ fn main() {
 	let module = parity_wasm::deserialize_file(&input).expect("Input module deserialization failed");
 
 	for section in module.sections() {
-		match *section {
-			elements::Section::Import(ref import_section) => {
+		match section {
+			elements::Section::Import(import_section) => {
 				let mut has_imported_memory_properly_named = false;
 				for entry in import_section.entries() {
 					if entry.module() != "env" {
 						fail("All imports should be from env");
 					}
-					match *entry.external() {
+					match entry.external() {
 						elements::External::Function(_) => {
 							if !ALLOWED_IMPORTS.contains(&entry.field()) {
 								fail(&format!("'{}' is not supported by the runtime", entry.field()));

--- a/src/build.rs
+++ b/src/build.rs
@@ -41,22 +41,23 @@ pub enum SourceTarget {
 impl std::fmt::Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
 		use self::Error::*;
-		match *self {
-			Encoding(ref err) => write!(f, "Encoding error ({})", err),
+		match self {
+			Encoding(err) => write!(f, "Encoding error ({})", err),
 			Optimizer => write!(f, "Optimization error due to missing export section. Pointed wrong file?"),
-			Packing(ref e) => write!(f, "Packing failed due to module structure error: {}. Sure used correct libraries for building contracts?", e),
+			Packing(e) => write!(f, "Packing failed due to module structure error: {}. Sure used correct libraries for building contracts?", e),
 		}
 	}
 }
 
 fn has_ctor(module: &elements::Module, target_runtime: &TargetRuntime) -> bool {
-	if let Some(ref section) = module.export_section() {
+	if let Some(section) = module.export_section() {
 		section.entries().iter().any(|e| target_runtime.symbols().create == e.field())
 	} else {
 		false
 	}
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build(
 	mut module: elements::Module,
 	source_target: SourceTarget,

--- a/src/export_globals.rs
+++ b/src/export_globals.rs
@@ -22,9 +22,8 @@ pub fn export_mutable_globals(
 		module.sections_mut().push(elements::Section::Export(elements::ExportSection::default()));
 	}
 
-	let mut symbol_index = 0usize;
 	let prefix: String = prefix.into();
-	for export in exports {
+	for (symbol_index, export) in exports.into_iter().enumerate() {
 		let new_entry = elements::ExportEntry::new(
 			format!("{}_{}", prefix, symbol_index),
 			elements::Internal::Global(
@@ -35,7 +34,6 @@ pub fn export_mutable_globals(
 			.expect("added above if does not exists")
 			.entries_mut()
 			.push(new_entry);
-		symbol_index += 1;
 	}
 }
 

--- a/src/gas/validation.rs
+++ b/src/gas/validation.rs
@@ -168,7 +168,7 @@ fn build_control_flow_graph(
 		}
 
 		let instruction_cost = rules.process(instruction)?;
-		match *instruction {
+		match instruction {
 			Instruction::Block(_) => {
 				graph.increment_actual_cost(active_node_id, instruction_cost);
 
@@ -221,7 +221,7 @@ fn build_control_flow_graph(
 				graph.increment_actual_cost(active_node_id, instruction_cost);
 
 				let active_frame_idx = stack.len() - 1;
-				let target_frame_idx = active_frame_idx - (label as usize);
+				let target_frame_idx = active_frame_idx - (*label as usize);
 				graph.new_edge(active_node_id, &stack[target_frame_idx]);
 
 				// Next instruction is unreachable, but carry on anyway.
@@ -233,7 +233,7 @@ fn build_control_flow_graph(
 				graph.increment_actual_cost(active_node_id, instruction_cost);
 
 				let active_frame_idx = stack.len() - 1;
-				let target_frame_idx = active_frame_idx - (label as usize);
+				let target_frame_idx = active_frame_idx - (*label as usize);
 				graph.new_edge(active_node_id, &stack[target_frame_idx]);
 
 				let new_node_id = graph.add_node();
@@ -241,7 +241,7 @@ fn build_control_flow_graph(
 				graph.new_forward_edge(active_node_id, new_node_id);
 				graph.set_first_instr_pos(new_node_id, cursor + 1);
 			}
-			Instruction::BrTable(ref br_table_data) => {
+			Instruction::BrTable(br_table_data) => {
 				graph.increment_actual_cost(active_node_id, instruction_cost);
 
 				let active_frame_idx = stack.len() - 1;
@@ -303,7 +303,7 @@ fn validate_graph_gas_costs(graph: &ControlFlowGraph) -> bool {
 		}
 
 		for loop_node_id in node.loopback_edges.iter() {
-			let (ref mut loop_actual, ref mut loop_charged) = loop_costs.get_mut(loop_node_id)
+			let (loop_actual, loop_charged) = loop_costs.get_mut(loop_node_id)
 				.expect("cannot arrive at loopback edge without visiting loop entry node");
 			if loop_actual != loop_charged {
 				return false;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -285,11 +285,11 @@ impl Default for Set {
 
 impl Set {
 	pub fn new(regular: u32, entries: Map<InstructionType, Metering>) -> Self {
-		Set { regular: regular, entries: entries, grow: 0 }
+		Set { regular, entries, grow: 0 }
 	}
 
 	pub fn process(&self, instruction: &elements::Instruction) -> Result<u32, ()>  {
-		match self.entries.get(&InstructionType::op(instruction)).map(|x| *x) {
+		match self.entries.get(&InstructionType::op(instruction)).cloned() {
 			None | Some(Metering::Regular) => Ok(self.regular),
 			Some(Metering::Forbidden) => Err(()),
 			Some(Metering::Fixed(val)) => Ok(val),

--- a/src/stack_height/mod.rs
+++ b/src/stack_height/mod.rs
@@ -149,7 +149,7 @@ fn generate_stack_height_global(module: &mut elements::Module) -> u32 {
 
 	// Try to find an existing global section.
 	for section in module.sections_mut() {
-		if let elements::Section::Global(ref mut gs) = *section {
+		if let elements::Section::Global(gs) = section {
 			gs.entries_mut().push(global_entry);
 			return (gs.entries().len() as u32) - 1;
 		}
@@ -212,7 +212,7 @@ fn compute_stack_cost(func_idx: u32, module: &elements::Module) -> Result<u32, E
 
 fn instrument_functions(ctx: &mut Context, module: &mut elements::Module) -> Result<(), Error> {
 	for section in module.sections_mut() {
-		if let elements::Section::Code(ref mut code_section) = *section {
+		if let elements::Section::Code(code_section) = section {
 			for func_body in code_section.bodies_mut() {
 				let opcodes = func_body.code_mut();
 				instrument_function(ctx, opcodes)?;
@@ -270,8 +270,8 @@ fn instrument_function(
 
 		let action: Action = {
 			let instruction = &instructions.elements()[cursor];
-			match *instruction {
-				Call(ref callee_idx) => {
+			match instruction {
+				Call(callee_idx) => {
 					let callee_stack_cost = ctx
 						.stack_cost(*callee_idx)
 						.ok_or_else(||
@@ -347,8 +347,8 @@ fn resolve_func_type(
 			.expect("function import count is not zero; import section must exists; qed")
 			.entries()
 			.iter()
-			.filter_map(|entry| match *entry.external() {
-				elements::External::Function(ref idx) => Some(*idx),
+			.filter_map(|entry| match entry.external() {
+				elements::External::Function(idx) => Some(*idx),
 				_ => None,
 			})
 			.nth(func_idx as usize)
@@ -363,7 +363,7 @@ fn resolve_func_type(
 			.ok_or_else(|| Error(format!("Function at index {} is not defined", func_idx)))?
 			.type_ref()
 	};
-	let Type::Function(ref ty) = *types.get(sig_idx as usize).ok_or_else(|| {
+	let Type::Function(ty) = types.get(sig_idx as usize).ok_or_else(|| {
 		Error(format!(
 			"Signature {} (specified by func {}) isn't defined",
 			sig_idx, func_idx

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -34,8 +34,8 @@ pub(crate) fn generate_thunks(
 		let start_func_idx = module
 			.start_section();
 
-		let exported_func_indices = exports.iter().filter_map(|entry| match *entry.internal() {
-			Internal::Function(ref function_idx) => Some(*function_idx),
+		let exported_func_indices = exports.iter().filter_map(|entry| match entry.internal() {
+			Internal::Function(function_idx) => Some(*function_idx),
 			_ => None,
 		});
 		let table_func_indices = elem_segments
@@ -119,7 +119,7 @@ pub(crate) fn generate_thunks(
 	let fixup = |function_idx: &mut u32| {
 		// Check whether this function is in replacement_map, since
 		// we can skip thunk generation (e.g. if stack_cost of function is 0).
-		if let Some(ref thunk) = replacement_map.get(function_idx) {
+		if let Some(thunk) = replacement_map.get(function_idx) {
 			*function_idx = thunk
 				.idx
 				.expect("At this point an index must be assigned to each thunk");
@@ -127,22 +127,22 @@ pub(crate) fn generate_thunks(
 	};
 
 	for section in module.sections_mut() {
-		match *section {
-			elements::Section::Export(ref mut export_section) => {
+		match section {
+			elements::Section::Export(export_section) => {
 				for entry in export_section.entries_mut() {
-					if let Internal::Function(ref mut function_idx) = *entry.internal_mut() {
+					if let Internal::Function(function_idx) = entry.internal_mut() {
 						fixup(function_idx)
 					}
 				}
 			}
-			elements::Section::Element(ref mut elem_section) => {
+			elements::Section::Element(elem_section) => {
 				for segment in elem_section.entries_mut() {
 					for function_idx in segment.members_mut() {
 						fixup(function_idx)
 					}
 				}
 			}
-			elements::Section::Start(ref mut start_idx) => {
+			elements::Section::Start(start_idx) => {
 				fixup(start_idx)
 			}
 			_ => {}

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -19,7 +19,7 @@ pub fn resolve_function(module: &elements::Module, index: u32) -> Symbol {
 	let mut functions = 0;
 	if let Some(import_section) = module.import_section() {
 		for (item_index, item) in import_section.entries().iter().enumerate() {
-			if let &elements::External::Function(_) = item.external() {
+			if let elements::External::Function(_) = item.external() {
 				if functions == index {
 					return Symbol::Import(item_index as usize);
 				}
@@ -35,7 +35,7 @@ pub fn resolve_global(module: &elements::Module, index: u32) -> Symbol {
 	let mut globals = 0;
 	if let Some(import_section) = module.import_section() {
 		for (item_index, item) in import_section.entries().iter().enumerate() {
-			if let &elements::External::Global(_) = item.external() {
+			if let elements::External::Global(_) = item.external() {
 				if globals == index {
 					return Symbol::Import(item_index as usize);
 				}
@@ -84,15 +84,15 @@ pub fn expand_symbols(module: &elements::Module, set: &mut Set<Symbol>) {
 			Export(idx) => {
 				let entry = &module.export_section().expect("Export section to exist").entries()[idx];
 				match entry.internal() {
-					&elements::Internal::Function(func_idx) => {
-						let symbol = resolve_function(module, func_idx);
+					elements::Internal::Function(func_idx) => {
+						let symbol = resolve_function(module, *func_idx);
 						if !stop.contains(&symbol) {
 							fringe.push(symbol);
 						}
 						set.insert(symbol);
 					},
-					&elements::Internal::Global(global_idx) => {
-						let symbol = resolve_global(module, global_idx);
+					elements::Internal::Global(global_idx) => {
+						let symbol = resolve_global(module, *global_idx);
 						if !stop.contains(&symbol) {
 							fringe.push(symbol);
 						}
@@ -103,8 +103,8 @@ pub fn expand_symbols(module: &elements::Module, set: &mut Set<Symbol>) {
 			},
 			Import(idx) => {
 				let entry = &module.import_section().expect("Import section to exist").entries()[idx];
-				if let &elements::External::Function(type_idx) = entry.external() {
-					let type_symbol = Symbol::Type(type_idx as usize);
+				if let elements::External::Function(type_idx) = entry.external() {
+					let type_symbol = Symbol::Type(*type_idx as usize);
 					if !stop.contains(&type_symbol) {
 						fringe.push(type_symbol);
 					}


### PR DESCRIPTION
The current code uses a lot of non idiomatic or otherwise problematic constructs. Those make the code more difficult to understand than necessary and sometimes even have performance implications.

Additionally, a huge amount of warnings can deter external contributors (like me) because the usage of clippy is not useful in such a codebase.

The changes don't change the behaviour of the code  and should be largely non-controversial. I would like to point out one specific code pattern that I eradicated:

The code made heavy use of the `ref (mut)` pattern to bind something as reference instead of as value. However, in all cases they were either just plain superfluous or could be replaced by  referencing once in the `match` statement. I would argue that they are rarely necessary and make the code harder to understand due to their rarity in common codebases.