### PR TITLE
Upgrade to `parity-wasm` 0.42.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwasm-utils"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2018"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -47,7 +47,7 @@ required-features = ["cli"]
 [dependencies]
 # If you add the feature "bulk", make sure you fixed all expects that say
 # "parity-wasm is compiled without bulk-memory operations"
-parity-wasm = { version = "0.41.0", default-features = false }
+parity-wasm = { version = "0.42.1", default-features = false }
 log = { version = "0.4", default-features = false }
 byteorder = { version = "1", default-features = false }
 

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -11,7 +11,7 @@ use crate::std::cmp::min;
 use crate::std::mem;
 use crate::std::vec::Vec;
 
-use parity_wasm::{elements, builder};
+use parity_wasm::{elements, elements::ValueType, builder};
 use crate::rules::Rules;
 
 pub fn update_call_index(instructions: &mut elements::Instructions, inserted_index: u32) {
@@ -250,7 +250,7 @@ fn add_grow_counter<R: Rules>(
 	let mut b = builder::from_module(module);
 	b.push_function(
 		builder::function()
-			.signature().params().i32().build().with_return_type(Some(elements::ValueType::I32)).build()
+			.signature().with_param(ValueType::I32).with_result(ValueType::I32).build()
 			.body()
 				.with_instructions(elements::Instructions::new(vec![
 					GetLocal(0),
@@ -441,7 +441,7 @@ pub fn inject_gas_counter<R: Rules>(
 	let mut mbuilder = builder::from_module(module);
 	let import_sig = mbuilder.push_signature(
 		builder::signature()
-			.param().i32()
+			.with_param(ValueType::I32)
 			.build_sig()
 		);
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -75,7 +75,7 @@ pub fn pack_instance(raw_module: Vec<u8>, mut ctor_module: elements::Module, tar
 		if !func.params().is_empty() {
 			return Err(Error::InvalidCreateSignature(target.symbols().create));
 		}
-		if func.return_type().is_some() {
+		if !func.results().is_empty() {
 			return Err(Error::InvalidCreateSignature(target.symbols().create));
 		}
 

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -173,7 +173,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 
 	// Add implicit frame for the function. Breaks to this frame and execution of
 	// the last end should deal with this frame.
-	let func_arity: u32 = if func_signature.return_type().is_some() {
+	let func_arity: u32 = if !func_signature.results().is_empty() {
 		1
 	} else {
 		0
@@ -279,7 +279,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 				stack.pop_values(ty.params().len() as u32)?;
 
 				// Push result of the function execution to the stack.
-				let callee_arity = if ty.return_type().is_some() { 1 } else { 0 };
+				let callee_arity = if !ty.results().is_empty() { 1 } else { 0 };
 				stack.push_values(callee_arity)?;
 			}
 			CallIndirect(x, _) => {
@@ -295,7 +295,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 				stack.pop_values(ty.params().len() as u32)?;
 
 				// Push result of the function execution to the stack.
-				let callee_arity = if ty.return_type().is_some() { 1 } else { 0 };
+				let callee_arity = if !ty.results().is_empty() { 1 } else { 0 };
 				stack.push_values(callee_arity)?;
 			}
 			Drop => {

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -173,11 +173,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 
 	// Add implicit frame for the function. Breaks to this frame and execution of
 	// the last end should deal with this frame.
-	let func_arity: u32 = if !func_signature.results().is_empty() {
-		1
-	} else {
-		0
-	};
+	let func_arity = func_signature.results().len() as u32;
 	stack.push_frame(Frame {
 		is_polymorphic: false,
 		end_arity: func_arity,
@@ -279,7 +275,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 				stack.pop_values(ty.params().len() as u32)?;
 
 				// Push result of the function execution to the stack.
-				let callee_arity = if !ty.results().is_empty() { 1 } else { 0 };
+				let callee_arity = ty.results().len() as u32;
 				stack.push_values(callee_arity)?;
 			}
 			CallIndirect(x, _) => {
@@ -295,7 +291,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 				stack.pop_values(ty.params().len() as u32)?;
 
 				// Push result of the function execution to the stack.
-				let callee_arity = if !ty.results().is_empty() { 1 } else { 0 };
+				let callee_arity = ty.results().len() as u32;
 				stack.push_values(callee_arity)?;
 			}
 			Drop => {

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -99,7 +99,7 @@ pub(crate) fn generate_thunks(
 				// Signature of the thunk should match the original function signature.
 				.signature()
 					.with_params(thunk.signature.params().to_vec())
-					.with_return_type(thunk.signature.return_type())
+					.with_results(thunk.signature.results().to_vec())
 					.build()
 				.body()
 					.with_instructions(elements::Instructions::new(


### PR DESCRIPTION
Needed for https://github.com/paritytech/cargo-contract/pull/119, where we can't upgrade `parity-wasm` because `wasm-utils` doesn't support the latest `parity-wasm` release yet.

I discovered https://github.com/paritytech/parity-wasm/issues/295 during the upgrade.