### PR TITLE
stack_height: `if` instruction should pop one value from the stack

### DIFF
--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -558,8 +558,8 @@ mod tests {
 	(func $main
 		block (result i32)
 			block (result i32)
-			i32.const 99
-			br 1
+				i32.const 99
+				br 1
 			end
 		end
 		drop


### PR DESCRIPTION
The current code does not consider that the `if` pops one argument from the stack on entering. See the added test which fails without this fix.