### PR TITLE
Export the complete `parity-wasm` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwasm-utils"
-version = "0.17.2"
+version = "0.18.0"
 edition = "2018"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/cli/build/main.rs
+++ b/cli/build/main.rs
@@ -1,20 +1,14 @@
 //! Experimental build tool for cargo
 
-#[macro_use]
-extern crate clap;
-extern crate glob;
-extern crate pwasm_utils as utils;
-extern crate parity_wasm;
-use pwasm_utils::logger;
+use pwasm_utils::{build, BuildError, SourceTarget, TargetRuntime, logger};
 
 mod source;
 
 use std::{fs, io};
 use std::path::PathBuf;
 
-use clap::{App, Arg};
+use clap::{App, Arg, crate_version};
 use parity_wasm::elements;
-use utils::{build, BuildError, SourceTarget, TargetRuntime};
 
 #[derive(Debug)]
 pub enum Error {
@@ -210,9 +204,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-	extern crate tempdir;
-
-	use self::tempdir::TempDir;
+	use tempdir::TempDir;
 	use std::fs;
 
 	use super::process_output;

--- a/cli/build/source.rs
+++ b/cli/build/source.rs
@@ -3,7 +3,7 @@
 pub const UNKNOWN_TRIPLET: &str = "wasm32-unknown-unknown";
 pub const EMSCRIPTEN_TRIPLET: &str = "wasm32-unknown-emscripten";
 
-use utils::SourceTarget;
+use pwasm_utils::SourceTarget;
 
 /// Configuration of previous build step (cargo compilation)
 #[derive(Debug)]

--- a/cli/check/main.rs
+++ b/cli/check/main.rs
@@ -1,8 +1,4 @@
-extern crate parity_wasm;
-extern crate pwasm_utils as utils;
 use pwasm_utils::logger;
-extern crate clap;
-
 use clap::{App, Arg};
 use parity_wasm::elements;
 

--- a/cli/ext/main.rs
+++ b/cli/ext/main.rs
@@ -1,20 +1,13 @@
-extern crate parity_wasm;
-extern crate pwasm_utils as utils;
-use pwasm_utils::logger;
-
-use std::env;
-
 fn main() {
+	pwasm_utils::logger::init();
 
-	logger::init();
-
-	let args = env::args().collect::<Vec<_>>();
+	let args = std::env::args().collect::<Vec<_>>();
 	if args.len() != 3 {
 		println!("Usage: {} input_file.wasm output_file.wasm", args[0]);
 		return;
 	}
 
-	let module = utils::externalize(
+	let module = pwasm_utils::externalize(
 		parity_wasm::deserialize_file(&args[1]).expect("Module to deserialize ok"),
 		vec!["_free", "_malloc", "_memcpy", "_memset", "_memmove"],
 	);

--- a/cli/gas/main.rs
+++ b/cli/gas/main.rs
@@ -1,7 +1,4 @@
-extern crate parity_wasm;
-extern crate pwasm_utils as utils;
-use pwasm_utils::logger;
-
+use pwasm_utils::{self as utils, logger};
 use std::env;
 
 fn main() {

--- a/cli/pack/main.rs
+++ b/cli/pack/main.rs
@@ -1,8 +1,4 @@
-extern crate parity_wasm;
-extern crate pwasm_utils as utils;
-use pwasm_utils::logger;
-extern crate clap;
-
+use pwasm_utils::{self as utils, logger};
 use clap::{App, Arg};
 
 fn main() {

--- a/cli/prune/main.rs
+++ b/cli/prune/main.rs
@@ -1,8 +1,4 @@
-extern crate parity_wasm;
-extern crate pwasm_utils as utils;
-use pwasm_utils::logger;
-extern crate clap;
-
+use pwasm_utils::{self as utils, logger};
 use clap::{App, Arg};
 
 fn main() {

--- a/cli/stack_height/main.rs
+++ b/cli/stack_height/main.rs
@@ -1,9 +1,5 @@
-extern crate pwasm_utils as utils;
-extern crate parity_wasm;
-use pwasm_utils::logger;
-
+use pwasm_utils::{logger, stack_height};
 use std::env;
-use utils::stack_height;
 
 fn main() {
 	logger::init();

--- a/examples/opt_imports.rs
+++ b/examples/opt_imports.rs
@@ -1,5 +1,3 @@
-extern crate pwasm_utils as utils;
-
 use std::env;
 
 fn main() {
@@ -10,7 +8,7 @@ fn main() {
 	}
 
 	// Loading module
-	let mut module = utils::Module::from_elements(
+	let mut module = pwasm_utils::Module::from_elements(
 		&parity_wasm::deserialize_file(&args[1]).expect("Module deserialization to succeed")
 	).expect("Failed to parse parity-wasm format");
 

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -512,9 +512,6 @@ pub fn inject_gas_counter<R: Rules>(
 
 #[cfg(test)]
 mod tests {
-
-	extern crate wabt;
-
 	use parity_wasm::{serialize, builder, elements};
 	use parity_wasm::elements::Instruction::*;
 	use super::*;
@@ -578,7 +575,7 @@ mod tests {
 		);
 
 		let binary = serialize(injected_module).expect("serialization failed");
-		self::wabt::wasm2wat(&binary).unwrap();
+		wabt::wasm2wat(&binary).unwrap();
 	}
 
 	#[test]
@@ -617,7 +614,7 @@ mod tests {
 		assert_eq!(injected_module.functions_space(), 2);
 
 		let binary = serialize(injected_module).expect("serialization failed");
-		self::wabt::wasm2wat(&binary).unwrap();
+		wabt::wasm2wat(&binary).unwrap();
 	}
 
 	#[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -771,10 +771,8 @@ pub fn generate(f: &Module) -> Result<Vec<u8>, Error> {
 
 #[cfg(test)]
 mod tests {
-
-	extern crate wabt;
-
 	use parity_wasm::elements;
+	use indoc::indoc;
 
 	fn load_sample(wat: &'static str) -> super::Module {
 		super::parse(&wabt::wat2wasm(wat).expect("faled to parse wat!")[..])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,6 @@
 #[macro_use]
 extern crate alloc;
 
-extern crate byteorder;
-extern crate parity_wasm;
-#[macro_use] extern crate log;
-#[cfg(test)] #[macro_use] extern crate indoc;
-#[cfg(test)] extern crate rand;
-#[cfg(test)] extern crate binaryen;
-
-
 pub mod rules;
 
 mod build;
@@ -43,6 +35,7 @@ pub use ref_list::{RefList, Entry, EntryRef, DeleteTransaction};
 #[cfg(feature = "std")]
 pub use export_globals::export_mutable_globals;
 pub use parity_wasm::elements::Instruction;
+use parity_wasm;
 
 pub struct TargetSymbols {
 	pub create: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ pub use graph::{Module, parse as graph_parse, generate as graph_generate};
 pub use ref_list::{RefList, Entry, EntryRef, DeleteTransaction};
 #[cfg(feature = "std")]
 pub use export_globals::export_mutable_globals;
-pub use parity_wasm::elements::Instruction;
-use parity_wasm;
+pub use parity_wasm;
 
 pub struct TargetSymbols {
 	pub create: &'static str,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use log::LevelFilter;
+use log::{LevelFilter, trace};
 use env_logger::Builder;
 use lazy_static::lazy_static;
 

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -5,8 +5,8 @@ use crate::std::collections::{BTreeSet as Set};
 use crate::std::vec::Vec;
 use crate::std::mem;
 
+use log::trace;
 use parity_wasm::elements;
-
 use crate::symbols::{Symbol, expand_symbols, push_code_symbols, resolve_function};
 
 #[derive(Debug)]

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -218,8 +218,6 @@ pub fn pack_instance(raw_module: Vec<u8>, mut ctor_module: elements::Module, tar
 
 #[cfg(test)]
 mod test {
-	extern crate parity_wasm;
-
 	use parity_wasm::builder;
 	use super::*;
 	use super::super::optimize;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -5,7 +5,7 @@ use crate::std::collections::BTreeMap as Map;
 
 use crate::std::num::NonZeroU32;
 use crate::std::str::FromStr;
-use crate::Instruction;
+use parity_wasm::elements::Instruction;
 
 pub struct UnknownInstruction;
 

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -1,5 +1,6 @@
 use crate::std::vec::Vec;
 
+use log::trace;
 use parity_wasm::elements::{self, BlockType, Type};
 use super::{resolve_func_type, Error};
 
@@ -428,7 +429,6 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 
 #[cfg(test)]
 mod tests {
-	extern crate wabt;
 	use parity_wasm::elements;
 	use super::*;
 

--- a/src/stack_height/mod.rs
+++ b/src/stack_height/mod.rs
@@ -374,7 +374,6 @@ fn resolve_func_type(
 
 #[cfg(test)]
 mod tests {
-	extern crate wabt;
 	use parity_wasm::elements;
 	use super::*;
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -4,6 +4,7 @@ use crate::std::collections::{HashSet as Set};
 use crate::std::collections::{BTreeSet as Set};
 use crate::std::vec::Vec;
 
+use log::trace;
 use parity_wasm::elements;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,12 +1,8 @@
-extern crate diff;
-extern crate pwasm_utils as utils;
-extern crate wabt;
-extern crate parity_wasm;
-
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use parity_wasm::elements;
+use pwasm_utils as utils;
 
 fn slurp<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 	let mut f = fs::File::open(path)?;


### PR DESCRIPTION
Besides converting the crate to the Rust 2018 style imports we now export the whole `parity-wasm`crate. Reason is that we use types of that crate in public interface. This forces downstream crates to sync the `parity-wasm` and `pwasm-utils` versions just to use this crate.

With this change downstream crates can just use the exported `parity-wasm` and do not need to specify a version for it in their `Cargo.toml` when using both.