### PR TITLE
Add BLESS env option

### DIFF
--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -66,9 +66,11 @@ fn run_diff_test<F: FnOnce(&[u8]) -> Vec<u8>>(test_dir: &str, name: &str, test: 
 			}
 		}
 
-		dump(&expected_path, actual_wat.as_bytes()).expect("Failed to write to expected");
-
-		panic!();
+		if std::env::var("BLESS").is_ok() {
+			dump(&expected_path, actual_wat.as_bytes()).expect("Failed to write to expected");
+		} else {
+			panic!();
+		}
 	}
 }
 

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -66,7 +66,7 @@ fn run_diff_test<F: FnOnce(&[u8]) -> Vec<u8>>(test_dir: &str, name: &str, test: 
 			}
 		}
 
-		if std::env::var("BLESS").is_ok() {
+		if std::env::var_os("BLESS").is_some() {
 			dump(&expected_path, actual_wat.as_bytes()).expect("Failed to write to expected");
 		} else {
 			panic!();


### PR DESCRIPTION
Right now if there is a diff between the actual and expected results,
the expected file will be overwritten. This may be annoying. To make it
controlled we introduce BLESS option.

This means that the expected files won't be regenerated unless this
environment variable is set.

Therefore to regenerate the tests use:

    BLESS=1 cargo test