### PR TITLE
Fix counting of the local variables

### DIFF
--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -93,6 +93,7 @@ mod stack_height {
 	def_stack_height_test!(table);
 	def_stack_height_test!(global);
 	def_stack_height_test!(imports);
+	def_stack_height_test!(many_locals);
 }
 
 mod gas {

--- a/tests/expectations/stack-height/many_locals.wat
+++ b/tests/expectations/stack-height/many_locals.wat
@@ -1,0 +1,21 @@
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i64 i64 i32))
+  (func (;1;) (type 0)
+    global.get 0
+    i32.const 3
+    i32.add
+    global.set 0
+    global.get 0
+    i32.const 1024
+    i32.gt_u
+    if  ;; label = @1
+      unreachable
+    end
+    call 0
+    global.get 0
+    i32.const 3
+    i32.sub
+    global.set 0)
+  (global (;0;) (mut i32) (i32.const 0)))

--- a/tests/fixtures/stack-height/many_locals.wat
+++ b/tests/fixtures/stack-height/many_locals.wat
@@ -1,0 +1,10 @@
+(module
+	(func $one-group-many-locals
+		(local i64) (local i64) (local i32)
+	)
+	(func $main
+		(call
+			$one-group-many-locals
+		)
+  	)
+)


### PR DESCRIPTION
The code assumed that the number of `Local` and number of locals is the
same thing. In reality though it is not. `Local` actually represents a
group of locals with the same type. The group can declare more than one
variable and the number of them is returned by `Local::count`.

In this PR we acknowledge this fact. Along the way we add a checked
arithmetic for locals_count and max_stack_height summation.