### PR TITLE
Global based gas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["wasm", "webassembly", "pwasm"]
 parity-wasm = { version = "0.41.0", default-features = false }
 log = { version = "0.4", default-features = false }
 byteorder = { version = "1", default-features = false }
+wasmprinter = "0.2.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -393,14 +393,13 @@ pub fn inject_gas_counter(module: elements::Module, rules: &rules::Set)
 	// Injecting gas counting global
 	let mut mbuilder = builder::from_module(module)
 		.with_global(GlobalEntry::new(
-		GlobalType::new(ValueType::I64, true),
-		InitExpr::new(vec![Instruction::I64Const(0)]),
+		GlobalType::new(ValueType::I32, true),
+		InitExpr::new(vec![Instruction::I32Const(0), Instruction::End]),
 	));
 
 	// back to plain module
 	let mut module = mbuilder.build();
 
-	println!("{:?}", module.global_section().unwrap().entries());
 	let gas_global = module.global_section().unwrap().entries().len() as u32 - 1;
 	let mut error = false;
 
@@ -461,9 +460,7 @@ mod tests {
 				.build()
 			.build();
 
-		println!("{:?}", module);
 		let injected_module = inject_gas_counter(module, &rules::Set::default().with_grow_cost(10000)).unwrap();
-		println!("{:?}", injected_module);
 
 		assert_eq!(
 			get_function_body(&injected_module, 0).unwrap(),
@@ -477,8 +474,6 @@ mod tests {
 		);
 
 		let binary = serialize(injected_module).expect("serialization failed");
-		let wat = wasmprinter::print_bytes(&binary).unwrap();
-		println!("{}", wat);
 		self::wabt::wasm2wat(&binary).unwrap();
 	}
 

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -339,6 +339,7 @@ fn insert_metering_update(
 					GetGlobal(gas_global),
 					I32Const(block.cost as i32),
 					I32LtU,
+					If(elements::BlockType::NoResult),
 					Call(out_of_gas_callback),
 					End,
 					// gas_global -= block.cost
@@ -524,7 +525,15 @@ mod tests {
 		assert_eq!(
 			get_function_body(&injected_module, 0).unwrap(),
 			&vec![
+				GetGlobal(1),
 				I32Const(10002),
+				I32LtU,
+				If(elements::BlockType::NoResult),
+				Call(0),
+				End,
+				GetGlobal(1),
+				I32Const(10002),
+				I32Sub,
 				SetGlobal(1),
 				GetGlobal(0),
 				GrowMemory(0),

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -334,7 +334,7 @@ fn insert_metering_update(
 		// If there the next block starts at this position, inject metering instructions.
 		let used_block = if let Some(ref block) = block_iter.peek() {
 			if block.start_pos == original_pos {
-				new_instrs.extend(vec![t
+				new_instrs.extend(vec![
 					// if gas_global < block.cost: call host function out_of_gas_callback
 					GetGlobal(gas_global),
 					I32Const(block.cost as i32),

--- a/src/gas/mod.rs
+++ b/src/gas/mod.rs
@@ -332,8 +332,12 @@ fn insert_metering_update(
 		// If there the next block starts at this position, inject metering instructions.
 		let used_block = if let Some(ref block) = block_iter.peek() {
 			if block.start_pos == original_pos {
-				new_instrs.push(I32Const(block.cost as i32));
-				new_instrs.push(SetGlobal(gas_global));
+				new_instrs.extend(vec![
+					I32Const(block.cost as i32),
+					GetGlobal(gas_global),
+					I32Add,
+					SetGlobal(gas_global)
+				]);
 				true
 			} else { false }
 		} else { false };

--- a/tests/expectations/gas/branch.wat
+++ b/tests/expectations/gas/branch.wat
@@ -1,8 +1,18 @@
 (module
   (type (;0;) (func (result i32)))
-  (func (;0;) (type 0) (result i32)
+  (type (;1;) (func))
+  (import "env" "out_of_gas_callback" (func (;0;) (type 1)))
+  (func (;1;) (type 0) (result i32)
     (local i32 i32)
+    get_global 0
     i32.const 13
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 13
+    i32.sub
     set_global 0
     block  ;; label = @1
       i32.const 0
@@ -16,7 +26,15 @@
       set_local 1
       i32.const 1
       br_if 0 (;@1;)
+      get_global 0
       i32.const 5
+      i32.lt_u
+      if  ;; label = @2
+        call 0
+      end
+      get_global 0
+      i32.const 5
+      i32.sub
       set_global 0
       get_local 0
       get_local 1

--- a/tests/expectations/gas/branch.wat
+++ b/tests/expectations/gas/branch.wat
@@ -1,11 +1,9 @@
 (module
   (type (;0;) (func (result i32)))
-  (type (;1;) (func (param i32)))
-  (import "env" "gas" (func (;0;) (type 1)))
-  (func (;1;) (type 0) (result i32)
+  (func (;0;) (type 0) (result i32)
     (local i32 i32)
     i32.const 13
-    call 0
+    set_global 0
     block  ;; label = @1
       i32.const 0
       set_local 0
@@ -19,11 +17,12 @@
       i32.const 1
       br_if 0 (;@1;)
       i32.const 5
-      call 0
+      set_global 0
       get_local 0
       get_local 1
       tee_local 0
       i32.add
       set_local 1
     end
-    get_local 1))
+    get_local 1)
+  (global (;0;) (mut i32) (i32.const 0)))

--- a/tests/expectations/gas/call.wat
+++ b/tests/expectations/gas/call.wat
@@ -1,16 +1,34 @@
 (module
   (type (;0;) (func (param i32 i32) (result i32)))
-  (func (;0;) (type 0) (param i32 i32) (result i32)
+  (type (;1;) (func))
+  (import "env" "out_of_gas_callback" (func (;0;) (type 1)))
+  (func (;1;) (type 0) (param i32 i32) (result i32)
     (local i32)
+    get_global 0
     i32.const 5
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 5
+    i32.sub
     set_global 0
     get_local 0
     get_local 1
-    call 1
+    call 2
     set_local 2
     get_local 2)
-  (func (;1;) (type 0) (param i32 i32) (result i32)
+  (func (;2;) (type 0) (param i32 i32) (result i32)
+    get_global 0
     i32.const 3
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 3
+    i32.sub
     set_global 0
     get_local 0
     get_local 1

--- a/tests/expectations/gas/call.wat
+++ b/tests/expectations/gas/call.wat
@@ -1,19 +1,18 @@
 (module
   (type (;0;) (func (param i32 i32) (result i32)))
-  (type (;1;) (func (param i32)))
-  (import "env" "gas" (func (;0;) (type 1)))
-  (func (;1;) (type 0) (param i32 i32) (result i32)
+  (func (;0;) (type 0) (param i32 i32) (result i32)
     (local i32)
     i32.const 5
-    call 0
+    set_global 0
     get_local 0
     get_local 1
-    call 2
+    call 1
     set_local 2
     get_local 2)
-  (func (;2;) (type 0) (param i32 i32) (result i32)
+  (func (;1;) (type 0) (param i32 i32) (result i32)
     i32.const 3
-    call 0
+    set_global 0
     get_local 0
     get_local 1
-    i32.add))
+    i32.add)
+  (global (;0;) (mut i32) (i32.const 0)))

--- a/tests/expectations/gas/ifs.wat
+++ b/tests/expectations/gas/ifs.wat
@@ -1,17 +1,43 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (func (;0;) (type 0) (param i32) (result i32)
+  (type (;1;) (func))
+  (import "env" "out_of_gas_callback" (func (;0;) (type 1)))
+  (func (;1;) (type 0) (param i32) (result i32)
+    get_global 0
     i32.const 2
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 2
+    i32.sub
     set_global 0
     i32.const 1
     if (result i32)  ;; label = @1
+      get_global 0
       i32.const 3
+      i32.lt_u
+      if  ;; label = @2
+        call 0
+      end
+      get_global 0
+      i32.const 3
+      i32.sub
       set_global 0
       get_local 0
       i32.const 1
       i32.add
     else
+      get_global 0
       i32.const 2
+      i32.lt_u
+      if  ;; label = @2
+        call 0
+      end
+      get_global 0
+      i32.const 2
+      i32.sub
       set_global 0
       get_local 0
       i32.popcnt

--- a/tests/expectations/gas/ifs.wat
+++ b/tests/expectations/gas/ifs.wat
@@ -1,20 +1,19 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i32)))
-  (import "env" "gas" (func (;0;) (type 1)))
-  (func (;1;) (type 0) (param i32) (result i32)
+  (func (;0;) (type 0) (param i32) (result i32)
     i32.const 2
-    call 0
+    set_global 0
     i32.const 1
     if (result i32)  ;; label = @1
       i32.const 3
-      call 0
+      set_global 0
       get_local 0
       i32.const 1
       i32.add
     else
       i32.const 2
-      call 0
+      set_global 0
       get_local 0
       i32.popcnt
-    end))
+    end)
+  (global (;0;) (mut i32) (i32.const 0)))

--- a/tests/expectations/gas/simple.wat
+++ b/tests/expectations/gas/simple.wat
@@ -1,23 +1,56 @@
 (module
   (type (;0;) (func))
-  (func (;0;) (type 0)
+  (import "env" "out_of_gas_callback" (func (;0;) (type 0)))
+  (func (;1;) (type 0)
+    get_global 0
     i32.const 2
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 2
+    i32.sub
     set_global 0
     i32.const 1
     if  ;; label = @1
+      get_global 0
       i32.const 1
+      i32.lt_u
+      if  ;; label = @2
+        call 0
+      end
+      get_global 0
+      i32.const 1
+      i32.sub
       set_global 0
       loop  ;; label = @2
+        get_global 0
         i32.const 2
+        i32.lt_u
+        if  ;; label = @3
+          call 0
+        end
+        get_global 0
+        i32.const 2
+        i32.sub
         set_global 0
         i32.const 123
         drop
       end
     end)
-  (func (;1;) (type 0)
+  (func (;2;) (type 0)
+    get_global 0
     i32.const 1
+    i32.lt_u
+    if  ;; label = @1
+      call 0
+    end
+    get_global 0
+    i32.const 1
+    i32.sub
     set_global 0
     block  ;; label = @1
     end)
   (global (;0;) (mut i32) (i32.const 0))
-  (export "simple" (func 0)))
+  (export "simple" (func 1)))

--- a/tests/expectations/gas/simple.wat
+++ b/tests/expectations/gas/simple.wat
@@ -1,24 +1,23 @@
 (module
   (type (;0;) (func))
-  (type (;1;) (func (param i32)))
-  (import "env" "gas" (func (;0;) (type 1)))
-  (func (;1;) (type 0)
+  (func (;0;) (type 0)
     i32.const 2
-    call 0
+    set_global 0
     i32.const 1
     if  ;; label = @1
       i32.const 1
-      call 0
+      set_global 0
       loop  ;; label = @2
         i32.const 2
-        call 0
+        set_global 0
         i32.const 123
         drop
       end
     end)
-  (func (;2;) (type 0)
+  (func (;1;) (type 0)
     i32.const 1
-    call 0
+    set_global 0
     block  ;; label = @1
     end)
-  (export "simple" (func 1)))
+  (global (;0;) (mut i32) (i32.const 0))
+  (export "simple" (func 0)))

--- a/tests/expectations/gas/start.wat
+++ b/tests/expectations/gas/start.wat
@@ -3,15 +3,24 @@
   (type (;1;) (func))
   (import "env" "ext_return" (func (;0;) (type 0)))
   (import "env" "memory" (memory (;0;) 1 1))
-  (func (;1;) (type 1)
+  (import "env" "out_of_gas_callback" (func (;1;) (type 1)))
+  (func (;2;) (type 1)
+    get_global 0
     i32.const 4
+    i32.lt_u
+    if  ;; label = @1
+      call 1
+    end
+    get_global 0
+    i32.const 4
+    i32.sub
     set_global 0
     i32.const 8
     i32.const 4
     call 0
     unreachable)
-  (func (;2;) (type 1))
+  (func (;3;) (type 1))
   (global (;0;) (mut i32) (i32.const 0))
-  (export "call" (func 2))
-  (start 1)
+  (export "call" (func 3))
+  (start 2)
   (data (i32.const 8) "\01\02\03\04"))

--- a/tests/expectations/gas/start.wat
+++ b/tests/expectations/gas/start.wat
@@ -1,18 +1,17 @@
 (module
   (type (;0;) (func (param i32 i32)))
   (type (;1;) (func))
-  (type (;2;) (func (param i32)))
   (import "env" "ext_return" (func (;0;) (type 0)))
   (import "env" "memory" (memory (;0;) 1 1))
-  (import "env" "gas" (func (;1;) (type 2)))
-  (func (;2;) (type 1)
+  (func (;1;) (type 1)
     i32.const 4
-    call 1
+    set_global 0
     i32.const 8
     i32.const 4
     call 0
     unreachable)
-  (func (;3;) (type 1))
-  (export "call" (func 3))
-  (start 2)
+  (func (;2;) (type 1))
+  (global (;0;) (mut i32) (i32.const 0))
+  (export "call" (func 2))
+  (start 1)
   (data (i32.const 8) "\01\02\03\04"))


### PR DESCRIPTION
This is the implementation in wasm-utils side. On nearcore side, need to:
1) access and mutate the gas counter that injected here in ** all host functions** using a run-time struct (Wasmer::Module, e.g.), instead of the compile-time struct (wasm_utils::Module)
2) Before every call of the contract, reset the gas counter global with the run-time wasm module struct to the prepaid gas.
3) implement a `out_of_gas_callback` in vm logic, which simply returns a GasLimitExceeded vm error, and import it to wasm env.
4) handle `(self.is_view || new_used_gas <= self.prepaid_gas)` after vm return since per cross-contract call prepaid gas is only available in host, as point out by @nearmax. Actually I just think that can we have two counters in wasm: used and burnt, set them before each contract call and let wasm gas counter decide they're used up. Once used up, invoke host side stub function to return GasLimitExceeded or GasExceeded. This would avoid a protocol change.


On this PR, I fixed unit tests. still have a few integration tests to fix, but quite straightfoward, just instructions replacement