### PR TITLE
Bump version and only include essential files in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwasm-utils"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2018"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -8,6 +8,7 @@ readme = "README.md"
 description = "Collection of command-line utilities and corresponding Rust api for producing pwasm-compatible executables"
 keywords = ["wasm", "webassembly", "pwasm"]
 repository = "https://github.com/paritytech/wasm-utils"
+include = ["src/**/*", "LICENSE-*", "README.md", "cli/**/*"]
 
 [[bin]]
 name = "wasm-prune"


### PR DESCRIPTION
In preparation for release to crates.io.