### PR TITLE
sign_ext feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,4 @@ cli = [
   "env_logger",
   "lazy_static",
 ]
+sign_ext = ["parity-wasm/sign_ext"]

--- a/src/gas/validation.rs
+++ b/src/gas/validation.rs
@@ -25,7 +25,7 @@ type NodeId = usize;
 
 /// A node in a control flow graph is commonly known as a basic block. This is a sequence of
 /// operations that are always executed sequentially.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct ControlFlowNode {
 	/// The index of the first instruction in the basic block. This is only used for debugging.
 	first_instr_pos: Option<usize>,
@@ -46,19 +46,6 @@ struct ControlFlowNode {
 
 	/// Edges in the "backwards" direction. These edges form cycles in the graph.
 	loopback_edges: Vec<NodeId>,
-}
-
-impl Default for ControlFlowNode {
-	fn default() -> Self {
-		ControlFlowNode {
-			first_instr_pos: None,
-			actual_cost: 0,
-			charged_cost: 0,
-			is_loop_target: false,
-			forward_edges: Vec::new(),
-			loopback_edges: Vec::new(),
-		}
-	}
 }
 
 /// A control flow graph where nodes are basic blocks and edges represent possible transitions

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -65,6 +65,9 @@ pub enum InstructionType {
 	Nop,
 	CurrentMemory,
 	GrowMemory,
+
+	#[cfg(feature = "sign_ext")]
+	SignExt,
 }
 
 impl FromStr for InstructionType {
@@ -92,6 +95,10 @@ impl FromStr for InstructionType {
 			"nop" => Ok(InstructionType::Nop),
 			"current_mem" => Ok(InstructionType::CurrentMemory),
 			"grow_mem" => Ok(InstructionType::GrowMemory),
+
+			#[cfg(feature = "sign_ext")]
+			"sign_ext" => Ok(InstructionType::SignExt),
+
 			_ => Err(UnknownInstruction),
 		}
 	}
@@ -290,6 +297,9 @@ impl InstructionType {
 			I64ReinterpretF64 => InstructionType::Reinterpretation,
 			F32ReinterpretI32 => InstructionType::Reinterpretation,
 			F64ReinterpretI64 => InstructionType::Reinterpretation,
+
+			#[cfg(feature = "sign_ext")]
+			SignExt(_) => InstructionType::SignExt,
 		}
 	}
 }

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -4,6 +4,9 @@ use super::{resolve_func_type, Error};
 use log::trace;
 use parity_wasm::elements::{self, BlockType, Type};
 
+#[cfg(feature = "sign_ext")]
+use parity_wasm::elements::SignExtInstruction;
+
 /// Control stack frame.
 #[derive(Debug)]
 struct Frame {
@@ -407,6 +410,16 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 			F64PromoteF32 | I32ReinterpretF32 | I64ReinterpretF64 | F32ReinterpretI32 |
 			F64ReinterpretI64 => {
 				// Conversion operators take one value and produce one result.
+				stack.pop_values(1)?;
+				stack.push_values(1)?;
+			},
+
+			#[cfg(feature = "sign_ext")]
+			SignExt(SignExtInstruction::I32Extend8S) |
+			SignExt(SignExtInstruction::I32Extend16S) |
+			SignExt(SignExtInstruction::I64Extend8S) |
+			SignExt(SignExtInstruction::I64Extend16S) |
+			SignExt(SignExtInstruction::I64Extend32S) => {
 				stack.pop_values(1)?;
 				stack.push_values(1)?;
 			},


### PR DESCRIPTION
This adds support for the parity-wasm `sign_ext` feature flag, by adding the same feature flag to this library.