### PR TITLE
Deprecate this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pwasm-utils
 
-[![Build Status](https://travis-ci.org/paritytech/wasm-utils.svg?branch=master)](https://travis-ci.org/paritytech/wasm-utils)
+> :warning: **This repository/crate is deprecated and unmaintained**: Switch to [`wasm-instrument`](https://github.com/paritytech/wasm-instrument) in order to use wasm instrumentation (gas metering, stack height limiter) in your project. For wasm code optimization [`binaryen`](https://github.com/WebAssembly/binaryen) should be used.
 
 A collection of WASM utilities used in pwasm-ethereum and substrate contract development.
 


### PR DESCRIPTION
I created a successor crate with a proper crate name and without all the dead code. This repository should be archived after this is merged and a last release was made to crates.io (so that this README shows up there).

Substrate is switched to the new crate here: https://github.com/paritytech/substrate/pull/10680